### PR TITLE
CouchDB 2.X.X 32bit build instructions

### DIFF
--- a/INSTALL_32.md
+++ b/INSTALL_32.md
@@ -44,7 +44,7 @@ pip install sphinx docutils pygments
 *Note: Do NOT install curl or help2man inside CygWin!*
 
 ## Mozilla build
-Fetch the latest Mozilla Build version from
+Fetch [Mozilla Build 2.2](https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-2.2.0.exe) from
 https://wiki.mozilla.org/MozillaBuild and install to c:\mozilla-build
 with all defaults.
 
@@ -217,7 +217,7 @@ Start by launching a fresh `CouchDB SDK prompt`, then setup the
 Mozilla build environment with the command:
 
 ```dos
-call c:\mozilla-build\start-shell-msvc2013-x64.bat
+call c:\mozilla-build\start-shell-msvc2013.bat
 ```
 
 Now, ensure the output of `which cl lc link mt rc make` matches
@@ -242,7 +242,7 @@ tar xzf bits/js185-1.0.0.tar.gz
 patch -p0 </c/relax/couchdb-glazier/bits/js185-msvc2013.patch
 cd js-1.8.5/js/src
 autoconf-2.13
-./configure --enable-static --enable-shared-js --disable-debug-symbols --disable-debug --disable-debugger-info-modules --target=x86_64-pc-mingw32 --host=x86_64-pc-mingw32
+./configure --enable-static --enable-shared-js --disable-debug-symbols --disable-debug --disable-debugger-info-modules
 make
 ```
 
@@ -261,6 +261,8 @@ make check
 Close the prompt window by entering `exit` twice.
 
 ## Building CouchDB itself
+
+Before compiling CouchDB, you need to make sure that rebar is installed on your system and accessible via your %PATH% environment.
 
 Start a new `SDK prompt`, then run `c:\relax\bin\shell.cmd`.
 Select `Erlang 18.3` and `w for a Windows prompt`.

--- a/INSTALL_32.md
+++ b/INSTALL_32.md
@@ -1,0 +1,350 @@
+# Glazier
+
+Glazier is a set of batch files, scripts and toolchains designed to
+ease building CouchDB on Windows. It's as fully automated as
+possible, with most of the effort required only once.
+
+Glazier uses the MS Visual Studio 2013 toolchain as much as possible,
+to ensure a quality Windows experience and to execute all binary
+dependencies within the same runtime.
+
+We hope Glazier simplifies using Erlang and CouchDB for you, giving
+a consistent, repeatable build environment.
+
+
+# Base Requirements
+
+- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB*.
+  - We like 64-bit Windows 7, 8.1 or 10 Enterprise N (missing Media Player, etc.) from MSDN.
+- If prompted, reboot after installing the .NET framework.
+- [Visual Studio 2013 x86 Community Edition](https://www.visualstudio.com/vs/older-downloads/) installed on the *C: drive*. Downloading requires a free Dev Essentials subscription from Microsoft.
+- [Chocolatey](https://chocolatey.org). From an *administrative* __cmd.exe__ command prompt, run:
+
+```dos
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+```
+
+- Apply Windows Updates and reboot until no more updates appear.
+- If using a VM, shutdown and snapshot your VM at this point.
+
+# Install Pre-requisites
+
+## Clean Package Installs with Chocolatey, cyg-get and pip
+
+These packages install silently, without intervention. Cut and paste them
+into an **Administrator** command prompt.
+
+```dos
+cinst -y git 7zip.commandline StrawberryPerl nasm cyg-get wixtoolset python aria2 nodejs.install make
+cinst -y nssm --version 2.24.101-g897c7ad
+cyg-get p7zip autoconf binutils bison gcc-code gcc-g++ gdb git libtool make patchutils pkg-config readline file renameutils socat time tree util-linux wget
+pip install sphinx docutils pygments
+```
+
+*Note: Do NOT install curl or help2man inside CygWin!*
+
+## Mozilla build
+Fetch the latest Mozilla Build version from
+https://wiki.mozilla.org/MozillaBuild and install to c:\mozilla-build
+with all defaults.
+
+## Make a new prompt shortcut
+
+Make a new shortcut on the desktop. The location should be:
+
+```dos
+cmd.exe /E:ON /V:ON /T:1F /K ""C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" x86 && color 1f
+```
+
+Name it "CouchDB SDK Prompt".
+
+Right-click on the icon, select Properties, click the `Advanced...`
+button, and tick the `Run as administrator` checkbox. Click OK twice.
+
+I suggest you pin it to the Start menu. We'll use this all the time.
+
+Start a CouchDB SDK Prompt window and run 
+`where cl mc mt link lc rc nmake make`. Make sure the output matches the
+following:
+
+```dos
+C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\cl.exe
+C:\Program Files (x86)\Windows Kits\8.1\bin\x86\mc.exe
+C:\Program Files (x86)\Windows Kits\8.1\bin\x86\mt.exe
+C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\link.exe
+C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\lc.exe
+C:\Program Files (x86)\Windows Kits\8.1\bin\x86\rc.exe
+C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\nmake.exe
+C:\ProgramData\chocolatey\bin\make.exe
+```
+
+Stop here if your results are not *identical*. If you are unable to
+reproduce these results, please open an issue on this repository for
+assistance.
+
+## Set up required convenience links & environment variable
+
+In the CouchDB SDK Prompt, run the following commands:
+
+```dos
+mkdir c:\relax    
+cd c:\relax
+rd /s/q SDK VC nasm inno5 nsis strawberry
+mklink /j c:\relax\bin c:\relax\couchdb-glazier\bin
+mklink /j c:\relax\nasm "c:\Program Files (x86)\NASM"
+mklink /j c:\relax\SDK "c:\Program Files (x86)\Windows Kits\8.1"
+mklink /j c:\relax\VC "C:\Program Files (x86)\Microsoft Visual Studio 12.0"
+mklink /j c:\openssl c:\relax\openssl
+setx RELAX c:\relax
+```
+
+Close all open command prompts. Now we're ready to go!
+
+# Building CouchDB Pre-requisites
+
+## Downloading glazier and dependency sources
+
+Open a new `CouchDB SDK Prompt` and run the following:
+
+```dos
+cd c:\relax
+git config --global core.autocrlf input
+git clone https://github.com/apache/couchdb-glazier
+aria2c --force-sequential=false --max-connection-per-server=5 --check-certificate=false --auto-file-renaming=false --allow-overwrite=true --input-file=couchdb-glazier/downloads_32.md --max-concurrent-downloads=5 --dir=bits --save-session=bits/a2session.txt
+color 1f
+```
+
+As of 2017-07-08, this will download the source for the following versions of our dependencies:
+
+* MS Visual C++ x86 Redistributable for VC12 with patches
+* OpenSSL 1.0.2l
+* curl 7.49.1
+* Erlang:
+  * 17.5
+  * 18.3
+  * 19.3
+* ICU4C 57.1 (*Note*: this is the last version to support building in VS2013)
+* SpiderMonkey 1.8.5
+
+
+## Build & Test 86-bit OpenSSL
+
+In the same `CouchDB SDK Prompt`, run the following:
+
+```dos
+cd %RELAX%\bin && build_openssl_32.cmd
+```
+
+Close your `CouchDB SDK Prompt`.
+
+## Build 32-bit libcurl
+
+Open a new `CouchDB SDK Prompt` and run the following:
+
+```dos
+cd %RELAX%\bin && build_curl_32.cmd
+```
+
+## Build 32-bit ICU
+
+In the same `CouchDB SDK Prompt` run the following:
+
+```dos
+cd %RELAX%\bin && build_icu_32.cmd
+```
+
+Close the window.
+
+## Start a UNIX-friendly shell with MS compilers
+
+1. Start your `CouchDB SDK Prompt` as above
+2. Launch a cygwin erl-ified shell via `c:\relax\bin\shell_32.cmd`
+3. Select 18.3 (unless you know what you are doing!)
+4. Select `b for bash prompt`.
+
+For more detail on why this is necessary, see
+[UNIX-friendly shell details](#unix-friendly-shell-details) below.
+
+## Unpack, configure and build Erlang/OTP 18.3
+
+At the bash prompt, enter the following commands:
+
+```bash
+ln -s /cygdrive/c/relax /relax
+cd .. && tar xzf /relax/bits/otp_src_18.3.tar.gz
+cd $ERL_TOP
+echo "skipping gs" > lib/gs/SKIP
+echo "skipping wx" > lib/wx/SKIP
+echo "skipping ic" > lib/ic/SKIP
+echo "skipping jinterface" > lib/jinterface/SKIP
+eval `$ERL_TOP/otp_build env_win32`
+```
+
+At this point, check your paths. Run `which cl link mc lc mt nmake rc`.
+The output should match the following:
+
+```bash
+/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/cl
+/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/link
+/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/mc
+/cygdrive/c/PROGRA~2/MICROS~1/Windows/v8.1A/bin/NETFX4~1.1TO/lc
+/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/mt
+/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/nmake
+/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/rc
+```
+
+If it does not, stop and diagnose.
+
+Now you can proceed to build Erlang, closing the window when
+done:
+
+```bash
+erl_config_32.sh
+# Ensure OpenSSL is found by the configure script.
+# If you see any warnings, stop and diagnose.
+erl_build.sh
+exit
+exit
+```
+
+## Build Spidermonkey JavaScript 1.8.5
+
+Spidermonkey needs to be compiled with the Mozilla Build chain.
+To build it with VS2013 requires a few patches contained in this
+repository.
+
+Start by launching a fresh `CouchDB SDK prompt`, then setup the
+Mozilla build environment with the command:
+
+```dos
+call c:\mozilla-build\start-shell-msvc2013-x64.bat
+```
+
+Now, ensure the output of `which cl lc link mt rc make` matches
+the following:
+
+```dos
+/c/Program Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64/cl.exe
+/c/Program Files (x86)/Microsoft SDKs/Windows/v8.1A/bin/NETFX 4.5.1 Tools/x64/lc.exe
+gram Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64/link.exe
+/c/Program Files (x86)/Windows Kits/8.1/bin/x64/mt.exe
+/c/Program Files (x86)/Windows Kits/8.1/bin/x64/rc.exe
+/local/bin/make.exe
+```
+
+If this does not match *exactly*, stop and diagnose.
+
+Now, proceed to patch and build SpiderMonkey 1.8.5:
+
+```bash
+cd /c/relax
+tar xzf bits/js185-1.0.0.tar.gz
+patch -p0 </c/relax/couchdb-glazier/bits/js185-msvc2013.patch
+cd js-1.8.5/js/src
+autoconf-2.13
+./configure --enable-static --enable-shared-js --disable-debug-symbols --disable-debug --disable-debugger-info-modules --target=x86_64-pc-mingw32 --host=x86_64-pc-mingw32
+make
+```
+
+If desired, tests can be run at this point. This is optional,
+takes a while, and the math-jit-tests may fail. For more detail
+as to why, see https://bugzilla.mozilla.org/show_bug.cgi?id=1076670
+Also, one jsapi test has been disabled that crashes; this exercises
+a call CouchDB doesn't use.
+
+To run the tests:
+
+```bash
+make check
+```
+
+Close the prompt window by entering `exit` twice.
+
+## Building CouchDB itself
+
+Start a new `SDK prompt`, then run `c:\relax\bin\shell.cmd`.
+Select `Erlang 18.3` and `w for a Windows prompt`.
+Then, run the following commands to download and build CouchDB
+from the master repository:
+
+```dos
+cd \relax && git clone https://github.com/apache/couchdb
+cd couchdb
+# optionally, switch to a different tag or branch for building with:
+# git checkout --track origin/2.0.x
+git clean -fdx && git reset --hard
+powershell -ExecutionPolicy Bypass .\configure.ps1 -WithCurl
+make -f Makefile.win check
+```
+
+This will build a development version of CouchDB runnable via
+
+```dos
+python dev\run <-n1> <--with-admin-party-please>
+```
+
+To build a self-contained CouchDB installation (also known as an Erlang
+_release_), after running the above use:
+
+```dos
+    make -f Makefile.win release
+```
+
+To build an installer using WiX to create a full Windows .msi, run:
+
+```dos
+    make -f Makefile.win release
+    cd \relax\glazier
+    bin\build_installer.cmd
+```
+
+You made it! Time to relax. :D
+
+# Appendix
+
+## Why Glazier?
+
+@dch first got involved with CouchDB around 0.7. Only having a low-spec Windows
+PC to develop on, and no CouchDB Cloud provider being available, he tried
+to build CouchDB himself. It was hard going, and most of the frustration was
+trying to get the core Erlang environment set up and compiling without needing
+to buy Microsoft's expensive but excellent Visual Studio tools. Once
+Erlang was working he found many of the pre-requisite modules such as cURL,
+Zlib, OpenSSL, Mozilla's SpiderMonkey JavaScript engine, and IBM's ICU were
+not available at a consistent compiler and VC runtime release.
+
+There is a branch of glazier that has been used to build each CouchDB release.
+
+## UNIX-friendly shell details
+
+Our goal is to get the path set up in this order:
+
+1. erlang and couchdb build helper scripts
+2. Microsoft VC compiler, linker, etc from Windows SDK
+3. cygwin path for other build tools like make, autoconf, libtool
+4. the remaining windows system path
+
+It seems this is a challenge for most environments, so `glazier` just
+assumes you're using [chocolatey] and takes care of the rest.
+
+Alternatively, you can launch your own cmd prompt, and ensure that your system
+path is correct first in the win32 side before starting cygwin. Once in cygwin
+go to the root of where you installed erlang, and run the Erlang/OTP script:
+
+        eval `./otp_build env_win32 x64`
+        echo $PATH | /bin/sed 's/:/\n/g'
+        which cl link mc lc mt nmake rc
+
+Confirm that output of `which` returns only MS versions from VC++ or the SDK.
+This is critical and if not correct will cause confusing errors much later on.
+Overall, the desired order for your $PATH is:
+
+- Erlang build helper scripts
+- Visual C++ / .NET framework / SDK
+- Ancillary Erlang and CouchDB packaging tools
+- Usual cygwin unix tools such as make, gcc
+- Ancillary glazier/relax tools for building dependent libraries
+- Usual Windows folders `%windir%;%windir%\system32` etc
+- Various settings form the `otp_build` script
+
+More details are at [erlang INSTALL-Win32.md on github](https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-WIN32.md)

--- a/INSTALL_32.md
+++ b/INSTALL_32.md
@@ -92,7 +92,7 @@ cd c:\relax
 rd /s/q SDK VC nasm inno5 nsis strawberry
 mklink /j c:\relax\bin c:\relax\couchdb-glazier\bin
 mklink /j c:\relax\nasm "c:\Program Files (x86)\NASM"
-mklink /j c:\relax\SDK "c:\Program Files (x86)\Windows Kits\8.1"
+mklink /j c:\relax\SDK "C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A"
 mklink /j c:\relax\VC "C:\Program Files (x86)\Microsoft Visual Studio 12.0"
 mklink /j c:\openssl c:\relax\openssl
 setx RELAX c:\relax

--- a/INSTALL_32.md
+++ b/INSTALL_32.md
@@ -14,7 +14,7 @@ a consistent, repeatable build environment.
 
 # Base Requirements
 
-- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB*.
+- 64-bit Windows 7 or 8.1. *This is required for Mozilla build setup*.
   - We like 64-bit Windows 7, 8.1 or 10 Enterprise N (missing Media Player, etc.) from MSDN.
 - If prompted, reboot after installing the .NET framework.
 - [Visual Studio 2013 x86 Community Edition](https://www.visualstudio.com/vs/older-downloads/) installed on the *C: drive*. Downloading requires a free Dev Essentials subscription from Microsoft.
@@ -29,19 +29,45 @@ a consistent, repeatable build environment.
 
 # Install Pre-requisites
 
-## Clean Package Installs with Chocolatey, cyg-get and pip
+## Clean Package Installs with Chocolatey, Cygwin and pip
 
 These packages install silently, without intervention. Cut and paste them
 into an **Administrator** command prompt.
 
 ```dos
-cinst -y git 7zip.commandline StrawberryPerl nasm cyg-get wixtoolset python aria2 nodejs.install make
-cinst -y nssm --version 2.24.101-g897c7ad
-cyg-get p7zip autoconf binutils bison gcc-code gcc-g++ gdb git libtool make patchutils pkg-config readline file renameutils socat time tree util-linux wget
+cinst -y git 7zip.commandline StrawberryPerl nasm wixtoolset python aria2 nodejs.install make
+cinst -y nssm --version 2.24.101-g897c7ad --x86
 pip install sphinx docutils pygments
 ```
 
+For Cygwin, install the 32bit version.
+
+Required packages:
+
+- cyg-get
+- p7zip
+- autoconf
+- binutils
+- bison
+- gcc-code
+- gcc- g++
+- gdb
+- git
+- libtool
+- make
+- patchutils
+- pkg-config
+- readline
+- file
+- renameutils
+- socat
+- time
+- tree
+- util-linux
+- wget
+
 *Note: Do NOT install curl or help2man inside CygWin!*
+*Note: If you have problems compiling erlang, I recommend you check most of the devel packages and hope for the best!*
 
 ## Mozilla build
 Fetch [Mozilla Build 2.2](https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-2.2.0.exe) from
@@ -98,6 +124,8 @@ mklink /j c:\openssl c:\relax\openssl
 setx RELAX c:\relax
 ```
 
+*Note: The SDK version might vary base on your OS. This was done with Windows 10 Professional*
+
 Close all open command prompts. Now we're ready to go!
 
 # Building CouchDB Pre-requisites
@@ -127,7 +155,7 @@ As of 2017-07-08, this will download the source for the following versions of ou
 * SpiderMonkey 1.8.5
 
 
-## Build & Test 86-bit OpenSSL
+## Build & Test 32-bit OpenSSL
 
 In the same `CouchDB SDK Prompt`, run the following:
 
@@ -158,7 +186,7 @@ Close the window.
 ## Start a UNIX-friendly shell with MS compilers
 
 1. Start your `CouchDB SDK Prompt` as above
-2. Launch a cygwin erl-ified shell via `c:\relax\bin\shell_32.cmd`
+2. Launch a cygwin erl-ified shell via `C:\relax\bin\shell_32.cmd`
 3. Select 18.3 (unless you know what you are doing!)
 4. Select `b for bash prompt`.
 
@@ -184,13 +212,13 @@ At this point, check your paths. Run `which cl link mc lc mt nmake rc`.
 The output should match the following:
 
 ```bash
-/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/cl
-/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/link
-/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/mc
-/cygdrive/c/PROGRA~2/MICROS~1/Windows/v8.1A/bin/NETFX4~1.1TO/lc
-/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/mt
-/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN/nmake
-/cygdrive/c/PROGRA~2/WI3CF2~1/8.1/bin/x86/rc
+/cygdrive/c/relax/VC/VC/bin/cl
+/cygdrive/c/relax/VC/VC/bin/link
+/cygdrive/c/Program Files (x86)/Windows Kits/8.1/bin/x86/mc
+/cygdrive/c/relax/SDK/bin/NETFX 4.5.1 Tools/lc
+/cygdrive/c/Program Files (x86)/Windows Kits/8.1/bin/x86/mt
+/cygdrive/c/relax/VC/VC/bin/nmake
+/cygdrive/c/Program Files (x86)/Windows Kits/8.1/bin/x86/rc
 ```
 
 If it does not, stop and diagnose.
@@ -224,9 +252,9 @@ Now, ensure the output of `which cl lc link mt rc make` matches
 the following:
 
 ```dos
-/c/Program Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64/cl.exe
+/c/Program Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64_x86/cl.exe
 /c/Program Files (x86)/Microsoft SDKs/Windows/v8.1A/bin/NETFX 4.5.1 Tools/x64/lc.exe
-gram Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64/link.exe
+/c/Program Files (x86)/Microsoft Visual Studio 12.0/VC/BIN/amd64_x86/link.exe
 /c/Program Files (x86)/Windows Kits/8.1/bin/x64/mt.exe
 /c/Program Files (x86)/Windows Kits/8.1/bin/x64/rc.exe
 /local/bin/make.exe
@@ -296,8 +324,8 @@ To build an installer using WiX to create a full Windows .msi, run:
 
 ```dos
     make -f Makefile.win release
-    cd \relax\glazier
-    bin\build_installer.cmd
+    cd \relax\couchdb-glazier
+    bin\build_installer_32.cmd
 ```
 
 You made it! Time to relax. :D

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ dependencies within the same runtime.
 We hope Glazier simplifies using Erlang and CouchDB for you, giving
 a consistent, repeatable build environment.
 
-For 32bit build instructions, see [this documentation](README_32.md)
+For 32bit build instructions, see [this documentation](INSTALL_32.md)
 
 
 # Base Requirements
 
-- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB. Altought, 32bit instructions are available [here](README_32.md)*.
+- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB. Altought, 32bit instructions are available [here](INSTALL_32.md)*.
   - We like 64-bit Windows 7, 8.1 or 10 Enterprise N (missing Media Player, etc.) from MSDN.
 - If prompted, reboot after installing the .NET framework.
 - [Visual Studio 2013 x64 Community Edition](https://www.visualstudio.com/vs/older-downloads/) installed on the *C: drive*. Downloading requires a free Dev Essentials subscription from Microsoft.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ dependencies within the same runtime.
 We hope Glazier simplifies using Erlang and CouchDB for you, giving
 a consistent, repeatable build environment.
 
+For 32bit build instructions, see [this documentation](/README_32.md)
+
 
 # Base Requirements
 
-- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB*.
+- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB. Altought, 32bit instructions are available [here](/README_32.md)*.
   - We like 64-bit Windows 7, 8.1 or 10 Enterprise N (missing Media Player, etc.) from MSDN.
 - If prompted, reboot after installing the .NET framework.
 - [Visual Studio 2013 x64 Community Edition](https://www.visualstudio.com/vs/older-downloads/) installed on the *C: drive*. Downloading requires a free Dev Essentials subscription from Microsoft.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ dependencies within the same runtime.
 We hope Glazier simplifies using Erlang and CouchDB for you, giving
 a consistent, repeatable build environment.
 
-For 32bit build instructions, see [this documentation](/README_32.md)
+For 32bit build instructions, see [this documentation](README_32.md)
 
 
 # Base Requirements
 
-- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB. Altought, 32bit instructions are available [here](/README_32.md)*.
+- 64-bit Windows 7 or 8.1. *As of CouchDB 2.0 we only support a 64-bit build of CouchDB. Altought, 32bit instructions are available [here](README_32.md)*.
   - We like 64-bit Windows 7, 8.1 or 10 Enterprise N (missing Media Player, etc.) from MSDN.
 - If prompted, reboot after installing the .NET framework.
 - [Visual Studio 2013 x64 Community Edition](https://www.visualstudio.com/vs/older-downloads/) installed on the *C: drive*. Downloading requires a free Dev Essentials subscription from Microsoft.

--- a/bin/build_curl_32.cmd
+++ b/bin/build_curl_32.cmd
@@ -1,0 +1,40 @@
+::setlocal
+path=%path%;%relax%\openssl\bin;
+
+for %%i in ("%relax%\bits\curl-*.zip") do set curl_ver=%%~ni
+setx CURL_VER %curl_ver%
+set CURL_VER=%curl_ver%
+setx CURL_SRC %curl_src%
+set CURL_SRC=%RELAX%\%curl_ver%
+setx CURL_PATH %curl_path%
+set CURL_PATH=%relax%\curl
+
+if not defined SSL_PATH echo OpenSSL not built && goto eof
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: clean up existing installs
+:: extract bundle and name
+:: stash SSL version
+if exist %curl_path% rd /s/q %curl_path%
+if defined curl_ver rd /s/q %curl_src%
+7z x "%RELAX%\bits\curl-*.zip" -o%RELAX% -y
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+pushd %curl_src%
+:: ensure curl can find OpenSSL libraries
+set USE_SSLEAY=1
+set USE_OPENSSL=1
+set OPENSSL_PATH=%SSL_PATH%
+set INCLUDE=%INCLUDE%;%SSL_PATH%\include;%SSL_PATH%\include\openssl;
+set LIBPATH=%LIBPATH%;%SSL_PATH%\lib;
+set LIB=%LIB%;%SSL_PATH%\lib;
+pushd %curl_src%
+cd winbuild
+nmake /f MakeFile.vc mode=static DEBUG=no
+popd
+:: make this specific curl version available to CouchDB build script
+mklink /d %curl_path% %curl_src%
+popd
+endlocal
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:eof

--- a/bin/build_curl_32.cmd
+++ b/bin/build_curl_32.cmd
@@ -14,8 +14,8 @@ if not defined SSL_PATH echo OpenSSL not built && goto eof
 :: clean up existing installs
 :: extract bundle and name
 :: stash SSL version
-::if exist %curl_path% rd /s/q %curl_path%
-::if defined curl_ver rd /s/q %curl_src%
+if exist %curl_path% rd /s/q %curl_path%
+if defined curl_ver rd /s/q %curl_src%
 7z x "%RELAX%\bits\curl-*.zip" -o%RELAX% -y
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -28,13 +28,11 @@ set INCLUDE=%INCLUDE%;%SSL_PATH%\include;%SSL_PATH%\include\openssl;
 set LIBPATH=%LIBPATH%;%SSL_PATH%\lib;
 set LIB=%LIB%;%SSL_PATH%\lib;
 pushd %curl_src%
-::cd winbuild
 nmake VC=VC12 VC12
 cd lib
 nmake /f Makefile.VC12 MACHINE=x86 cfg=release-dll
 cd ..\src
 nmake /f Makefile.VC12 MACHINE=x86 cfg=release-dll
-::nmake /f MakeFile.vc VC=12 mode=static DEBUG=no MACHINE=x86
 popd
 :: make this specific curl version available to CouchDB build script
 mklink /d %curl_path% %curl_src%

--- a/bin/build_curl_32.cmd
+++ b/bin/build_curl_32.cmd
@@ -4,9 +4,9 @@ path=%path%;%relax%\openssl\bin;
 for %%i in ("%relax%\bits\curl-*.zip") do set curl_ver=%%~ni
 setx CURL_VER %curl_ver%
 set CURL_VER=%curl_ver%
-setx CURL_SRC %curl_src%
+setx CURL_SRC "%curl_src%"
 set CURL_SRC=%RELAX%\%curl_ver%
-setx CURL_PATH %curl_path%
+setx CURL_PATH "%curl_path%"
 set CURL_PATH=%relax%\curl
 
 if not defined SSL_PATH echo OpenSSL not built && goto eof
@@ -14,8 +14,8 @@ if not defined SSL_PATH echo OpenSSL not built && goto eof
 :: clean up existing installs
 :: extract bundle and name
 :: stash SSL version
-if exist %curl_path% rd /s/q %curl_path%
-if defined curl_ver rd /s/q %curl_src%
+::if exist %curl_path% rd /s/q %curl_path%
+::if defined curl_ver rd /s/q %curl_src%
 7z x "%RELAX%\bits\curl-*.zip" -o%RELAX% -y
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -28,8 +28,13 @@ set INCLUDE=%INCLUDE%;%SSL_PATH%\include;%SSL_PATH%\include\openssl;
 set LIBPATH=%LIBPATH%;%SSL_PATH%\lib;
 set LIB=%LIB%;%SSL_PATH%\lib;
 pushd %curl_src%
-cd winbuild
-nmake /f MakeFile.vc mode=static DEBUG=no
+::cd winbuild
+nmake VC=VC12 VC12
+cd lib
+nmake /f Makefile.VC12 MACHINE=x86 cfg=release-dll
+cd ..\src
+nmake /f Makefile.VC12 MACHINE=x86 cfg=release-dll
+::nmake /f MakeFile.vc VC=12 mode=static DEBUG=no MACHINE=x86
 popd
 :: make this specific curl version available to CouchDB build script
 mklink /d %curl_path% %curl_src%

--- a/bin/build_icu_32.cmd
+++ b/bin/build_icu_32.cmd
@@ -1,0 +1,17 @@
+path=%path%;c:\mozilla-build\7zip;
+setlocal
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: icu doesn't have a version name in the archive path
+set ICU_PATH=%RELAX%\icu
+setx ICU_PATH %icu_path%
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: ensure we have a fresh source tree to build from
+if exist "%icu_path%" rd /s/q %icu_path%
+7z x "%relax%\bits\icu4c-*src.zip" -o%relax% -y
+pushd %icu_path%
+:: ICU is set up for MSVS 2010, this upgrades it to 2013 support
+devenv.com %icu_path%\source\allinone\allinone.sln /Upgrade
+devenv.com %icu_path%\source\allinone\allinone.sln /Build "Release|Win32"
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:eof
+endlocal

--- a/bin/build_icu_32.cmd
+++ b/bin/build_icu_32.cmd
@@ -3,7 +3,7 @@ setlocal
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: icu doesn't have a version name in the archive path
 set ICU_PATH=%RELAX%\icu
-setx ICU_PATH %icu_path%
+setx ICU_PATH "%icu_path%"
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: ensure we have a fresh source tree to build from
 if exist "%icu_path%" rd /s/q %icu_path%

--- a/bin/build_installer_32.cmd
+++ b/bin/build_installer_32.cmd
@@ -1,0 +1,73 @@
+@ECHO OFF
+
+:: Licensed under the Apache License, Version 2.0 (the "License"); you may not
+:: use this file except in compliance with the License. You may obtain a copy of
+:: the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+:: WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+:: License for the specific language governing permissions and limitations under
+:: the License.
+
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL DISABLEDELAYEDEXPANSION
+
+IF EXIST %~dp0..\..\couchdb\rel\couchdb (
+  SET COUCHDB=%~dp0..\..\couchdb\rel\couchdb
+) ELSE (
+  ECHO Error, couchdb release directory not found. Have you run make release?
+  GOTO END
+)
+
+SET OLDDIR=%cd%
+
+SET GLAZIER=%~dp0..
+SET /P START_ERL= < %COUCHDB%\releases\start_erl.data
+FOR /F "tokens=2" %%G IN ("%START_ERL%") DO SET APP_VSN=%%G
+
+:: pre-execution cleanup
+cd %GLAZIER%\installer
+rmdir /s /q release >NUL 2>&1
+del /f *.wixobj >NUL 2>&1
+del /f *.wixpdb >NUL 2>&1
+del /f couchdb.wxs couchdbfiles.wxs >NUL 2>&1
+
+:: add necessary DLLs to release directory
+xcopy %ICU_PATH%\bin\icu*.dll %COUCHDB%\bin /Y >NUL 2>&1
+xcopy %RELAX%\js-1.8.5\js\src\dist\bin\*.dll %COUCHDB%\bin /Y >NUL 2>&1
+copy %RELAX%\curl\lib\libcurl.dll %COUCHDB%\bin /Y >NUL 2>&1
+
+:: add nssm so we can create/delete the Windows service
+copy c:\ProgramData\Chocolatey\lib\nssm\tools\nssm-2.24-101-g897c7ad\nssm-2.24\win32\nssm.exe %COUCHDB%\bin /Y >NUL 2>&1
+
+:: update version number
+:: commented out because WiX insists on a #.#.#.# number format and there's
+:: no guarantee that's what we'll see
+copy couchdb_32.wxs.in couchdb.wxs >NUL 2>&1
+:: cscript //NoLogo %GLAZIER%\bin\sed.vbs s/####VERSION####/%APP_VSN% < couchdb.wxs.in >couchdb.wxs
+copy %COUCHDB%\etc\default.ini .
+echo file = ./var/log/couchdb.log >>default.ini
+cscript //NoLogo %GLAZIER%\bin\sed.vbs s/stderr/file < default.ini >%COUCHDB%\etc\default.ini
+
+:: Package CouchDB as a fragment
+:: WiX skips empty directories, so we create a dummy logfile
+echo New Log >%COUCHDB%\var\log\couchdb.log
+:: We don't want to re-run heat unless files have changed. And even then,
+:: we'd want to manually merge. heat will regenerate all GUIDS and that will
+:: cause problems in the field if we ever start upgrading rather than
+:: uninstall/reinstall. It's the -gg flag that results in this behaviour.
+heat dir %COUCHDB% -dr APPLICATIONFOLDER -cg CouchDBFilesGroup -gg -g1 -sfrag -srd -sw5150 -var "var.CouchDir" -out couchdbfiles.wxs
+
+:: Build MSI for installation
+candle -arch x86 -ext WiXUtilExtension couchdb.wxs
+candle -arch x86 -dCouchDir=%COUCHDB% couchdbfiles.wxs
+candle -arch x86 -ext WiXUtilExtension couchdb_wixui.wxs
+candle -arch x86 -ext WiXUtilExtension dirwarning.wxs
+light -sw1076 -ext WixUIExtension -ext WiXUtilExtension -cultures:en-us couchdb.wixobj couchdbfiles.wixobj couchdb_wixui.wixobj dirwarning.wixobj -out couchdb-%APP_VSN%.msi
+copy couchdb-%APP_VSN%.msi %OLDDIR%
+
+cd %OLDDIR%
+:END

--- a/bin/build_openssl_32.cmd
+++ b/bin/build_openssl_32.cmd
@@ -12,7 +12,7 @@ del /f/q "%TEMP%\openssl*.tar"
 for %%i in ("%TEMP%\openssl-*.tar") do set openssl_ver=%%~ni
 setx openssl_ver %openssl_ver%
 set SSL_PATH=%relax%\openssl
-setx SSL_PATH %ssl_path%
+setx SSL_PATH "%ssl_path%"
 
 if exist "%ssl_path%" rd /s/q "%ssl_path%"
 :: set up a softlink for openssl as Erlang seems to dumb to find it

--- a/bin/build_openssl_32.cmd
+++ b/bin/build_openssl_32.cmd
@@ -1,0 +1,42 @@
+setlocal
+path=%path%;c:\mozilla-build\7zip;%relax%\nasm;c:\strawberry\perl\bin;
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: clean up existing installs
+:: extract bundle and name
+:: stash SSL version
+del /f/q "%TEMP%\openssl*.tar"
+7z x "%relax%\bits\openssl-*.tar.gz" -y -o"%TEMP%"
+
+:: get the version of OpenSSL into the environment
+for %%i in ("%TEMP%\openssl-*.tar") do set openssl_ver=%%~ni
+setx openssl_ver %openssl_ver%
+set SSL_PATH=%relax%\openssl
+setx SSL_PATH %ssl_path%
+
+if exist "%ssl_path%" rd /s/q "%ssl_path%"
+:: set up a softlink for openssl as Erlang seems to dumb to find it
+if not exist c:\openssl mklink /j c:\openssl "%relax%\openssl"
+if not exist c:\OpenSSL-Win32 mklink /j c:\OpenSSL-Win32 "%relax%\openssl"
+if defined openssl_ver rd /s/q %relax%\%openssl_ver%
+7z x "%TEMP%\openssl-*.tar" -o%relax%\ -y
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+pushd %relax%\%openssl_ver%
+perl Configure VC-WIN32 no-asm --prefix=%ssl_path%
+call ms\do_ms
+nmake -f ms\nt.mak clean
+nmake -f ms\nt.mak all
+nmake -f ms\nt.mak test
+nmake -f ms\nt.mak install
+
+:: You may be surprised: the 64bit artefacts are indeed output in the
+:: out32* sub-directories and bear names ending *32.dll. Fact is the
+:: 64 bit compile target is so far an incremental change over the legacy
+:: 32bit windows target. Numerous compile flags are still labelled "32"
+:: although those do apply to both 32 and 64bit targets. 
+
+popd
+endlocal
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/bin/erl_config_32.sh
+++ b/bin/erl_config_32.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+pushd $ERL_TOP
+./otp_build autoconf 2>&1 | tee $ERL_TOP/build_autoconf.txt
+# from Erlang/OTP R14B03 onwards, Erlang by default is built with
+# *static* OpenSSL. Uncomment following, and change build_openssl.cmd
+# to revert this.
+## ./otp_build configure --enable-dynamic-ssl-lib --with-ssl=/cygdrive/c/openssl 2>&1 | tee $ERL_TOP/build_configure.txt
+export SSL_INCDIR='/cygdrive/c/OpenSSL-Win32'
+export SSL_INCLUDE='-I/cygdrive/c/OpenSSL-Win32/include'
+export SSL_LIBDIR='/cygdrive/c/OpenSSL-Win32/lib'
+export SSL_CRYPTO_LIBNAME='libeay32'
+export SSL_SSL_LIBNAME='ssleay32'
+mkdir /cygdrive/c/OpenSSL-Win32/lib/VC
+./otp_build configure --with-ssl=/cygdrive/c/OpenSSL-Win32 --without-javac 2>&1 | tee $ERL_TOP/build_configure.txt
+popd

--- a/bin/shell_32.cmd
+++ b/bin/shell_32.cmd
@@ -103,12 +103,16 @@ color
 title Building in %ERL_TOP% with OTP %OTP_REL% and Erlang v%ERTS_VSN%
 for /f "usebackq" %%i in (`c:\cygwin\bin\cygpath.exe %WERL_DIR%`) do @set WERL_PATH=%%i
 set ERL_TOP=%WERL_PATH%/otp_src_%OTP_REL%
-c:\cygwin\bin\bash %relax%\bin\shell.sh
+c:\cygwin\bin\bash %relax%\bin\shell_32.sh
 goto eof
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :win_shell
-echo type exit to stop relaxing.
+set ERL_TOP=%WERL_DIR%\otp_src_%OTP_REL%
+echo Type exit to stop relaxing.
+title On the couch. Type exit to stop relaxing.
+:: Need these things on the path to build/run CouchDB
+set PATH=%ERL_TOP%\release\win32\erts-%ERTS_VSN%\bin;%ERL_TOP%\bootstrap\bin;%ERL_TOP%\erts\etc\win32\cygwin_tools\vc;%ERL_TOP%\erts\etc\win32\cygwin_tools;%RELAX%\bin;%PATH%;%ICU_PATH%\bin;%RELAX%\js-1.8.5\js\src\dist\bin;%RELAX%\curl\lib;C:\Program files\Python36\Scripts;C:\Program Files\nodejs;C:\Program Files (x86)\WiX Toolset v3.11\bin;C:\cygwin\bin
 cmd.exe /k
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/bin/shell_32.cmd
+++ b/bin/shell_32.cmd
@@ -1,0 +1,118 @@
+@echo off
+title Time to Relax.
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+set CYGWIN=nontsec nodosfilewarning
+if not exist c:\temp mkdir c:\temp
+set TEMP=c:\temp
+set TMP=c:\temp
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: following settings allow Erlang build to locate openssl correctly
+:: and CouchDB to find ICU, Curl, and SSL if required
+set USE_SSLEAY=1
+set USE_OPENSSL=1
+if not defined SSL_PATH  set SSL_PATH=%RELAX%\openssl
+if not defined ICU_PATH  set ICU_PATH=%RELAX%\icu
+if not defined CURL_PATH set CURL_PATH=%RELAX%\curl
+if not defined ZLIB_PATH set ZLIB_PATH=%RELAX%\zlib
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: LIB and INCLUDE are preset by Windows SDK and/or Visual C++ shells
+:: however VC++ uses LIB & INCLUDE and SDK uses Lib & Include. In Cygwin
+:: these are *NOT* the same but when we shell out to CL.exe and LINK.exe
+:: all is well again
+
+:: relax for couchdb
+:: werldir for building erlang
+
+if not defined RELAX setx RELAX e:\relax > NUL:
+if not defined RELAX set RELAX=e:\relax
+if not defined WERL_DIR setx WERL_DIR c:\werl > NUL:
+if not defined WERL_DIR set WERL_DIR=c:\werl
+
+set INCLUDE=%INCLUDE%;%SSL_PATH%\include\openssl;%SSL_PATH%\include;%CURL_PATH%\include\curl;%ICU_PATH%\include;
+set LIBPATH=%LIBPATH%;%SSL_PATH%\lib;%CURL_PATH%\lib;%ICU_PATH%\lib;
+set LIB=%LIB%;%SSL_PATH%\lib;%CURL_PATH%\lib;%ICU_PATH%\lib;
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: check which version of erlang setup we want
+:: pick up from jenkins if required
+if not defined BUILD_WITH_JENKINS goto select
+if not defined OTP_REL goto select
+goto %OTP_REL%
+:: no default, so let's ask the user instead!
+:: choice.exe exists on all windows platforms since MSDOS but not on XP
+:select
+echo Select an Erlang:
+echo       7 for Erlang 17.5 
+echo       8 for Erlang 18.3 (default)
+echo       9 for Erlang 19.3
+set /p choice="Make your selection ===> "
+if /i "%choice%"=="0" goto win_shell
+if /i "%choice%"=="7" goto 17.5
+if /i "%choice%"=="8" goto 18.3
+if /i "%choice%"=="9" goto 19.3
+:: else
+goto 18.3
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:17.5
+set ERTS_VSN=6.4
+set OTP_REL=17.5
+goto shell_select
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:18.3
+set ERTS_VSN=7.3
+set OTP_REL=18.3
+goto shell_select
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:19.3
+set ERTS_VSN=8.3
+set OTP_REL=19.3
+goto shell_select
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:shell_select
+for /f "usebackq" %%i in (`c:\tools\cygwin\bin\cygpath.exe %WERL_DIR%`) do @set WERL_PATH=%%i
+
+echo Select a shell:
+echo       w for Windows prompt (default)
+echo       b for bash prompt
+echo       p for PowerShell prompt
+set /p choice="Make your selection ===> "
+if /i "%choice%"=="w" goto win_shell
+if /i "%choice%"=="b" goto unix_shell
+if /i "%choice%"=="p" goto ps_shell
+:: else
+goto :win_shell
+
+:unix_shell
+set ERL_TOP=%WERL_PATH%/otp_src_%OTP_REL%
+color
+title Building in %ERL_TOP% with OTP %OTP_REL% and Erlang v%ERTS_VSN%
+c:\tools\cygwin\bin\bash %relax%\bin\shell_32.sh
+goto eof
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:win_shell
+set ERL_TOP=%WERL_DIR%\otp_src_%OTP_REL%
+echo Type exit to stop relaxing.
+title On the couch. Type exit to stop relaxing.
+:: Need these things on the path to build/run CouchDB
+set PATH=%ERL_TOP%\release\win32\erts-%ERTS_VSN%\bin;%ERL_TOP%\bootstrap\bin;%ERL_TOP%\erts\etc\win32\cygwin_tools\vc;%ERL_TOP%\erts\etc\win32\cygwin_tools;%RELAX%\bin;%PATH%;%ICU_PATH%\bin;%RELAX%\js-1.8.5\js\src\dist\bin;%RELAX%\curl\lib;C:\Python36\Scripts;C:\Program Files\nodejs;C:\Program Files (x86)\WiX Toolset v3.11\bin;C:\tools\cygwin\bin
+cmd.exe /k
+goto eof
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:ps_shell
+echo Type exit to stop relaxing.
+title On the couch. Type exit to stop relaxing.
+set PATH=%ERL_TOP%\release\win32\erts-%ERTS_VSN%\bin;%ERL_TOP%\bootstrap\bin;%ERL_TOP%\erts\etc\win32\cygwin_tools\vc;%ERL_TOP%\erts\etc\win32\cygwin_tools;c:\relax\bin;%PATH%;%ICU_PATH%\bin;C:\Relax\js-1.8.5\js\src\dist\bin;C:\relax\curl\lib;c:\ProgramData\chocolatey\lib\python3\tools\Scripts;C:\Program Files\nodejs;C:\Program Files (x86)\WiX Toolset v3.11\bin
+powershell
+goto eof
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:eof
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/bin/shell_32.sh
+++ b/bin/shell_32.sh
@@ -15,6 +15,9 @@ echo Using Erlang $ERTS_VSN OTP $OTP_VER in $ERL_TOP
 echo
 
 echo doing sanity checks
+
+RELAXRT=/cygdrive/c/relax
+
 # here we want to see that junction points are set up and
 # rebuild path from scratch as ./otp_build env_win32 gets it wrong
 # first up are erlang build helper scripts
@@ -22,20 +25,20 @@ PATH=$ERL_TOP/release/win32/erts-$ERTS_VSN/bin:$ERL_TOP/bootstrap/bin:$ERL_TOP/e
 
 # then MSVC9 binaries using the new junction points
 ###PATH=$PATH:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/IDE:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/Tools:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/VCPACK~1
-PATH=$PATH:/relax/vc/Common7/IDE:/relax/VC/VC/BIN:/relax/VC/Common7/Tools/relax/VC/VC/vcPackages
+PATH=$PATH:$RELAXRT/vc/Common7/IDE:$RELAXRT/VC/VC/bin:$RELAXRT/VC/Common7/Tools/:$RELAXRT/VC/VC/vcPackages
 
 #### then .Net framework which we need to have clean manifests and SxS for Win7 x64
 #PATH=$PATH:/cygdrive/c/WINDOWS/Microsoft.NET/Framework:/cygdrive/c/Microsoft.NET/Framework/v4.0.30319:/cygdrive/c/Microsoft.NET/Framework/v3.5
 
 # then SDKs
-###PATH=$PATH:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v7.0/bin
+###PATH=$PATH:/cygdrive/c/PROGRA~1//MICROS~1/Windows/v7.0/bin
 ###PATH=$PATH:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v6.0A/bin
-PATH=$PATH:/relax/SDK/bin:/relax/SDK/bin/x64
+PATH=$PATH:$RELAXRT/SDK/bin:$RELAXRT/SDK/bin/x64
 
 # some additional tools in SDK
 # C:\Program Files\Microsoft Windows Performance Toolkit;
 # C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\NETFX 4.0 Tools;
-PATH=$PATH:/cygdrive/c/Program\ Files\ \(x86\)/Microsoft\ Windows\ Performance\ Toolkit:/relax/SDK/bin/NETFX\ 4.5.1\ Tools:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x86:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x64
+PATH=$PATH:/cygdrive/c/Program\ Files\ \(x86\)/Microsoft\ Windows\ Performance\ Toolkit:$RELAXRT/SDK/bin/NETFX\ 4.5.1\ Tools:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x86:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x64
 
 # then erlang and couchdb build helper scripts
 PATH=$PATH:/cygdrive/c/openssl/bin:/cygdrive/c/relax/nsis:/cygdrive/c/relax/inno5
@@ -44,7 +47,7 @@ PATH=$PATH:/cygdrive/c/openssl/bin:/cygdrive/c/relax/nsis:/cygdrive/c/relax/inno
 PATH=$PATH:/usr/local/bin:/usr/bin:/bin
 
 # then glazier tools
-PATH=$PATH:/relax/bin:/relax/bits
+PATH=$PATH:$RELAXRT/bin:$RELAXRT/bits
 
 # then windows
 PATH=$PATH:`/usr/bin/cygpath $WINDIR`/system32:`/usr/bin/cygpath $WINDIR`:`/usr/bin/cygpath $WINDIR`/System32/Wbem:`/usr/bin/cygpath $WINDIR`/system32/WindowsPowerShell/v1.0

--- a/bin/shell_32.sh
+++ b/bin/shell_32.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# inspired by https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-WIN32.md
+# written by joan touzet (@wohali) and dave cottlehuber (@dch)
+
+# first, a base default path for cygwin
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:\
+/cygdrive/c/windows/system32:/cygdrive/c/windows:\
+/cygdrive/c/windows/system32/Wbem
+
+# utility functions from INSTALL-WIN32.md, forced to cygwin mode
+make_winpath()
+{
+  P=$1
+  cygpath -d "$P"
+}
+
+make_upath()
+{
+  P=$1
+  cygpath "$P"
+}
+
+
+# build for the right version of erlang
+echo Using Erlang $ERTS_VSN OTP $OTP_VER in $ERL_TOP
+echo
+
+# convenience variables
+C_DRV=/cygdrive/c
+PRG_FLS64=$C_DRV/Program\ Files
+PRG_FLS32=$C_DRV/Program\ Files\ \(x86\)
+
+# MSVS 2013
+VISUAL_STUDIO_ROOT32=$PRG_FLS32/Microsoft\ Visual\ Studio\ 12.0
+MS_SDK_ROOT64=$PRG_FLS32/Windows\ Kits/8.1
+NETFX_ROOT64=$PRG_FLS32/Microsoft\ SDKs/Windows/v8.1A/bin/NETFX\ 4.5.1\ Tools/x64
+# Okay, now mangle the paths and get rid of spaces by using short names
+WIN_VCROOT32=`make_winpath "$VISUAL_STUDIO_ROOT32"`
+VCROOT32=`make_upath $WIN_VCROOT32`
+WIN_SDKROOT64=`make_winpath "$MS_SDK_ROOT64"`
+SDKROOT64=`make_upath $WIN_SDKROOT64`
+WIN_NETFXROOT64=`make_winpath "$NETFX_ROOT64"`
+NETFXROOT64=`make_upath $WIN_NETFXROOT64`
+WIN_PROGRAMFILES32=`make_winpath "$PRG_FLS32"`
+PROGRAMFILES32=`make_upath $WIN_PROGRAMFILES32`
+
+WIN_PROGRAMFILES64=`make_winpath "$PRG_FLS64"`
+PROGRAMFILES64=`make_upath $WIN_PROGRAMFILES64`
+
+# nsis
+NSIS_BIN=$PRG_FLS32/NSIS
+# openssl
+OPENSSL_BIN=/cygdrive/c/relax/openssl/bin
+# skipping java
+
+# now a path to everything we are about to build
+ERL_PATH=$ERL_TOP/release/win32/erts-$ERTS_VSN/bin:\
+$ERL_TOP/bootstrap/bin:\
+$ERL_TOP/erts/etc/win32/cygwin_tools/vc:\
+$ERL_TOP/erts/etc/win32/cygwin_tools
+
+# path to everything Visual Studio 2013
+VC_PATH=$VCROOT32/Common7/IDE:$VCROOT32/VC/BIN:$VCROOT32/Common7/Tools:\
+$VCROOT32/VC/VCPackages:$NETFXROOT64:$SDKROOT64/bin/x86:\
+$SDKROOT64/bin
+
+# .Net framework which we need to have clean manifests and SxS for Win7 x86
+DOTNET_PATH=/cygdrive/c/WINDOWS/Microsoft.NET/Framework:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v4.0.30319:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v3.5
+
+# glazier tools
+GLAZIER_PATH=$PATH:/relax/bin:/relax/bits
+
+# put it all together
+PATH=$NSIS_BIN:$OPENSSL_BIN:$VC_PATH:$PATH:$DOTNET_PATH:$ERL_PATH:$GLAZIER_PATH
+
+# Microsoft SDK libpaths are set by setup.cmd
+
+CC_SH_DEBUG_LOG=$TMP/cc_r$OTP_VER.log
+LD_SH_DEBUG_LOG=$TMP/ld_r$OTP_VER.log
+RC_SH_DEBUG_LOG=$TMP/rc_r$OTP_VER.log
+MD_SH_DEBUG_LOG=$TMP/md_r$OTP_VER.log
+MC_SH_DEBUG_LOG=$TMP/mc_r$OTP_VER.log
+
+TERM=xterm
+
+export INCLUDE LIB LIBPATH PATH TMP ERL_TOP ERTS_VSN OTP_VER SHELL RELAX TERM CC_SH_DEBUG_LOG LD_SH_DEBUG_LOG RC_SH_DEBUG_LOG MD_SH_DEBUG_LOG MC_SH_DEBUG_LOG
+
+# ensure we have an ERL_TOP to go to
+mkdir -p $ERL_TOP > /dev/null 2>&1
+
+# add in otp_build settings
+eval `$ERL_TOP/otp_build env_win32`
+
+echo doing sanity checks...
+echo current path:
+echo $PATH | /bin/sed 's/:/\n/g'
+echo
+echo please check the toolkit paths point to Microsoft versions:
+which mc lc cl link mt rc cvtres
+echo
+
+echo Ready to build Erlang and CouchDB using Erlang $ERTS_VSN OTP $OTP_VER in $ERL_TOP
+echo Time to Relax.
+
+if [ -z "$BUILD_WITH_JENKINS" ] ; then
+  pushd $ERL_TOP
+  bash -i
+else
+	echo Working directory is: `pwd`
+	git clean -fdx
+	git reset --hard
+	./bootstrap
+	/relax/bin/couchdb_config.sh
+	/relax/bin/couchdb_build.sh
+fi
+

--- a/bin/shell_32.sh
+++ b/bin/shell_32.sh
@@ -27,28 +27,26 @@ echo
 
 # convenience variables
 C_DRV=/cygdrive/c
+PRG_FLS=$C_DRV/Program\ Files\ \(x86\)
 PRG_FLS64=$C_DRV/Program\ Files
-PRG_FLS32=$C_DRV/Program\ Files\ \(x86\)
 
 # MSVS 2013
-VISUAL_STUDIO_ROOT32=$PRG_FLS32/Microsoft\ Visual\ Studio\ 12.0
-MS_SDK_ROOT64=$PRG_FLS32/Windows\ Kits/8.1
-NETFX_ROOT64=$PRG_FLS32/Microsoft\ SDKs/Windows/v8.1A/bin/NETFX\ 4.5.1\ Tools/x64
+VISUAL_STUDIO_ROOT=$PRG_FLS/Microsoft\ Visual\ Studio\ 12.0
+MS_SDK_ROOT=$PRG_FLS/Windows\ Kits/8.1
+NETFX_ROOT=$PRG_FLS/Microsoft\ SDKs/Windows/v8.1A/bin/NETFX\ 4.5.1\ Tools
 # Okay, now mangle the paths and get rid of spaces by using short names
-WIN_VCROOT32=`make_winpath "$VISUAL_STUDIO_ROOT32"`
-VCROOT32=`make_upath $WIN_VCROOT32`
-WIN_SDKROOT64=`make_winpath "$MS_SDK_ROOT64"`
-SDKROOT64=`make_upath $WIN_SDKROOT64`
-WIN_NETFXROOT64=`make_winpath "$NETFX_ROOT64"`
-NETFXROOT64=`make_upath $WIN_NETFXROOT64`
-WIN_PROGRAMFILES32=`make_winpath "$PRG_FLS32"`
-PROGRAMFILES32=`make_upath $WIN_PROGRAMFILES32`
+WIN_VCROOT=`make_winpath "$VISUAL_STUDIO_ROOT"`
+VCROOT=`make_upath $WIN_VCROOT`
+WIN_SDKROOT=`make_winpath "$MS_SDK_ROOT"`
+SDKROOT=`make_upath $WIN_SDKROOT`
+WIN_NETFXROOT=`make_winpath "$NETFX_ROOT"`
+NETFXROOT=`make_upath $WIN_NETFXROOT`
+WIN_PROGRAMFILES=`make_winpath "$PRG_FLS"`
+PROGRAMFILES=`make_upath $WIN_PROGRAMFILES`
 
-WIN_PROGRAMFILES64=`make_winpath "$PRG_FLS64"`
-PROGRAMFILES64=`make_upath $WIN_PROGRAMFILES64`
 
 # nsis
-NSIS_BIN=$PRG_FLS32/NSIS
+NSIS_BIN=$PRG_FLS/NSIS
 # openssl
 OPENSSL_BIN=/cygdrive/c/relax/openssl/bin
 # skipping java
@@ -60,9 +58,8 @@ $ERL_TOP/erts/etc/win32/cygwin_tools/vc:\
 $ERL_TOP/erts/etc/win32/cygwin_tools
 
 # path to everything Visual Studio 2013
-VC_PATH=$VCROOT32/Common7/IDE:$VCROOT32/VC/BIN:$VCROOT32/Common7/Tools:\
-$VCROOT32/VC/VCPackages:$NETFXROOT64:$SDKROOT64/bin/x86:\
-$SDKROOT64/bin
+VC_PATH=$VCROOT/Common7/IDE:$VCROOT/VC/BIN:$VCROOT/Common7/Tools:\
+$VCROOT/VC/VCPackages:$NETFXROOT:$SDKROOT/bin/x86
 
 # .Net framework which we need to have clean manifests and SxS for Win7 x86
 DOTNET_PATH=/cygdrive/c/WINDOWS/Microsoft.NET/Framework:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v4.0.30319:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v3.5
@@ -72,6 +69,14 @@ GLAZIER_PATH=$PATH:/relax/bin:/relax/bits
 
 # put it all together
 PATH=$NSIS_BIN:$OPENSSL_BIN:$VC_PATH:$PATH:$DOTNET_PATH:$ERL_PATH:$GLAZIER_PATH
+
+LIBPATH="$LIBPATH:$VCROOT\\VC\\lib"
+
+LIB="$LIB:$VCROOT\\VC\\lib\\;$SDKROOT\\lib\\winv6.3\\um\\x86"
+
+INCLUDE="$INCLUDE:$VCROOT\\VC\\include\\;$SDKROOT\\include\\shared\\;\
+$SDKROOT\\include\\um;$SDKROOT\\include\\winrt\\;$SDKROOT\\include\\um\\gl"
+
 
 # Microsoft SDK libpaths are set by setup.cmd
 

--- a/bin/shell_32.sh
+++ b/bin/shell_32.sh
@@ -1,84 +1,64 @@
 #!/bin/bash
-# inspired by https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-WIN32.md
-# written by joan touzet (@wohali) and dave cottlehuber (@dch)
 
-# first, a base default path for cygwin
-PATH=/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin:\
-/cygdrive/c/windows/system32:/cygdrive/c/windows:\
-/cygdrive/c/windows/system32/Wbem
-
-# utility functions from INSTALL-WIN32.md, forced to cygwin mode
-make_winpath()
-{
-  P=$1
-  cygpath -d "$P"
-}
-
-make_upath()
-{
-  P=$1
-  cygpath "$P"
-}
-
+# The PATH variable should be Cygwinish
+# which is normally done during the eval `./otp_build env_win32` build step
+# current ./otp_build seems to get cygwin tools in the wrong place so MS linker
+# is overridden by the GNU one, which is not what we want. Wwe rebuild the path
+# from scratch to ensure tools are found in the right order.
+# Note significant differences between win32 OS and win64 OS paths.
+# TODO we can find a better way to do this in future
+## this is what we are looking for in order
+## /cygdrive/c/src/otp_src_R13B04/erts/etc/win32/cygwin_tools/vc:/cygdrive/c/src/otp_src_R13B04/erts/etc/win32/cygwin_tools:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/IDE:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/bin:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/Tools/:/cygdrive/c/Windows/MICROS~1.NET/FRAMEW~1/:/cygdrive/c/Windows/MICROS~1.NET/FRAMEW~1/:/cygdrive/c/Windows/MICROS~1.NET/FRAMEW~1/V20~1.507:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/VCPACK~1:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v6.0A/bin:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v7.0/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WINDOW~1/v1.0/:/cygdrive/c/PROGRA~2/NSIS:/cygdrive/c/OpenSSL/bin
 
 # build for the right version of erlang
 echo Using Erlang $ERTS_VSN OTP $OTP_VER in $ERL_TOP
 echo
 
-# convenience variables
-C_DRV=/cygdrive/c
-PRG_FLS=$C_DRV/Program\ Files\ \(x86\)
-PRG_FLS64=$C_DRV/Program\ Files
+echo doing sanity checks
+# here we want to see that junction points are set up and
+# rebuild path from scratch as ./otp_build env_win32 gets it wrong
+# first up are erlang build helper scripts
+PATH=$ERL_TOP/release/win32/erts-$ERTS_VSN/bin:$ERL_TOP/bootstrap/bin:$ERL_TOP/erts/etc/win32/cygwin_tools/vc:$ERL_TOP/erts/etc/win32/cygwin_tools
 
-# MSVS 2013
-VISUAL_STUDIO_ROOT=$PRG_FLS/Microsoft\ Visual\ Studio\ 12.0
-MS_SDK_ROOT=$PRG_FLS/Windows\ Kits/8.1
-NETFX_ROOT=$PRG_FLS/Microsoft\ SDKs/Windows/v8.1A/bin/NETFX\ 4.5.1\ Tools
-# Okay, now mangle the paths and get rid of spaces by using short names
-WIN_VCROOT=`make_winpath "$VISUAL_STUDIO_ROOT"`
-VCROOT=`make_upath $WIN_VCROOT`
-WIN_SDKROOT=`make_winpath "$MS_SDK_ROOT"`
-SDKROOT=`make_upath $WIN_SDKROOT`
-WIN_NETFXROOT=`make_winpath "$NETFX_ROOT"`
-NETFXROOT=`make_upath $WIN_NETFXROOT`
-WIN_PROGRAMFILES=`make_winpath "$PRG_FLS"`
-PROGRAMFILES=`make_upath $WIN_PROGRAMFILES`
+# then MSVC9 binaries using the new junction points
+###PATH=$PATH:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/IDE:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/BIN:/cygdrive/c/PROGRA~2/MICROS~1.0/Common7/Tools:/cygdrive/c/PROGRA~2/MICROS~1.0/VC/VCPACK~1
+PATH=$PATH:/relax/vc/Common7/IDE:/relax/VC/VC/BIN:/relax/VC/Common7/Tools/relax/VC/VC/vcPackages
 
+#### then .Net framework which we need to have clean manifests and SxS for Win7 x64
+#PATH=$PATH:/cygdrive/c/WINDOWS/Microsoft.NET/Framework:/cygdrive/c/Microsoft.NET/Framework/v4.0.30319:/cygdrive/c/Microsoft.NET/Framework/v3.5
 
-# nsis
-NSIS_BIN=$PRG_FLS/NSIS
-# openssl
-OPENSSL_BIN=/cygdrive/c/relax/openssl/bin
-# skipping java
+# then SDKs
+###PATH=$PATH:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v7.0/bin
+###PATH=$PATH:/cygdrive/c/PROGRA~1/MICROS~1/Windows/v6.0A/bin
+PATH=$PATH:/relax/SDK/bin:/relax/SDK/bin/x64
 
-# now a path to everything we are about to build
-ERL_PATH=$ERL_TOP/release/win32/erts-$ERTS_VSN/bin:\
-$ERL_TOP/bootstrap/bin:\
-$ERL_TOP/erts/etc/win32/cygwin_tools/vc:\
-$ERL_TOP/erts/etc/win32/cygwin_tools
+# some additional tools in SDK
+# C:\Program Files\Microsoft Windows Performance Toolkit;
+# C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\NETFX 4.0 Tools;
+PATH=$PATH:/cygdrive/c/Program\ Files\ \(x86\)/Microsoft\ Windows\ Performance\ Toolkit:/relax/SDK/bin/NETFX\ 4.5.1\ Tools:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x86:/cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/8.1/bin/x64
 
-# path to everything Visual Studio 2013
-VC_PATH=$VCROOT/Common7/IDE:$VCROOT/VC/BIN:$VCROOT/Common7/Tools:\
-$VCROOT/VC/VCPackages:$NETFXROOT:$SDKROOT/bin/x86
+# then erlang and couchdb build helper scripts
+PATH=$PATH:/cygdrive/c/openssl/bin:/cygdrive/c/relax/nsis:/cygdrive/c/relax/inno5
 
-# .Net framework which we need to have clean manifests and SxS for Win7 x86
-DOTNET_PATH=/cygdrive/c/WINDOWS/Microsoft.NET/Framework:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v4.0.30319:/cygdrive/c/WINDOWS/Microsoft.NET/Framework/v3.5
+# then cygwin tools
+PATH=$PATH:/usr/local/bin:/usr/bin:/bin
 
-# glazier tools
-GLAZIER_PATH=$PATH:/relax/bin:/relax/bits
+# then glazier tools
+PATH=$PATH:/relax/bin:/relax/bits
 
-# put it all together
-PATH=$NSIS_BIN:$OPENSSL_BIN:$VC_PATH:$PATH:$DOTNET_PATH:$ERL_PATH:$GLAZIER_PATH
+# then windows
+PATH=$PATH:`/usr/bin/cygpath $WINDIR`/system32:`/usr/bin/cygpath $WINDIR`:`/usr/bin/cygpath $WINDIR`/System32/Wbem:`/usr/bin/cygpath $WINDIR`/system32/WindowsPowerShell/v1.0
 
-LIBPATH="$LIBPATH:$VCROOT\\VC\\lib"
-
-LIB="$LIB:$VCROOT\\VC\\lib\\;$SDKROOT\\lib\\winv6.3\\um\\x86"
-
-INCLUDE="$INCLUDE:$VCROOT\\VC\\include\\;$SDKROOT\\include\\shared\\;\
-$SDKROOT\\include\\um;$SDKROOT\\include\\winrt\\;$SDKROOT\\include\\um\\gl"
-
-
-# Microsoft SDK libpaths are set by setup.cmd
+# remaining settings from otp_build env_win32 script
+OVERRIDE_TARGET="win32"
+CC="cc.sh"
+CXX="cc.sh"
+AR="ar.sh"
+RANLIB="true"
+OVERRIDE_CONFIG_CACHE="$ERL_TOP/erts/autoconf/win32.config.cache"
+OVERRIDE_CONFIG_CACHE_STATIC="$ERL_TOP/erts/autoconf/win32.config.cache.static"
+OVERRIDE_TARGET="win32"
+WIN32_WRAPPER_PATH="$ERL_TOP/erts/etc/win32/cygwin_tools/vc:$ERL_TOP/erts/etc/win32/cygwin_tools"
 
 CC_SH_DEBUG_LOG=$TMP/cc_r$OTP_VER.log
 LD_SH_DEBUG_LOG=$TMP/ld_r$OTP_VER.log
@@ -88,20 +68,19 @@ MC_SH_DEBUG_LOG=$TMP/mc_r$OTP_VER.log
 
 TERM=xterm
 
-export INCLUDE LIB LIBPATH PATH TMP ERL_TOP ERTS_VSN OTP_VER SHELL RELAX TERM CC_SH_DEBUG_LOG LD_SH_DEBUG_LOG RC_SH_DEBUG_LOG MD_SH_DEBUG_LOG MC_SH_DEBUG_LOG
+export OVERRIDE_TARGET CC CXX AR RANLIB OVERRIDE_CONFIG_CACHE_STATIC OVERRIDE_CONFIG_CACHE INCLUDE LIB LIBPATH LINK CL PATH TMP CC_SH LD_SH RC_SH MD_SH MC_SH ERL_TOP ERTS_VSN OTP_VER SHELL RELAX WIN32_WRAPPER_PATH OVERRIDE_TARGET TERM
 
 # ensure we have an ERL_TOP to go to
 mkdir -p $ERL_TOP > /dev/null 2>&1
 
-# add in otp_build settings
-eval `$ERL_TOP/otp_build env_win32`
+# this shouldn't change anything really
+### eval `./otp_build env_win32`
 
-echo doing sanity checks...
 echo current path:
 echo $PATH | /bin/sed 's/:/\n/g'
 echo
 echo please check the toolkit paths point to Microsoft versions:
-which mc lc cl link mt rc cvtres
+which mc lc cl link mt rc
 echo
 
 echo Ready to build Erlang and CouchDB using Erlang $ERTS_VSN OTP $OTP_VER in $ERL_TOP

--- a/downloads_32.md
+++ b/downloads_32.md
@@ -1,0 +1,23 @@
+### list of all files needed for build chain ###################################
+################################################################################
+### MSVC vcredist is very carefully chosen to match SDK and VC++ latest patches
+# http://www.microsoft.com/en-us/download/details.aspx?id=40784 for vc12
+https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe
+################################################################################
+### OpenSSL
+https://www.openssl.org/source/openssl-1.0.2l.tar.gz
+################################################################################
+### libcurl
+https://curl.haxx.se/download/curl-7.49.1.zip 
+################################################################################
+### Erlang
+http://www.erlang.org/download/otp_src_17.5.tar.gz
+http://www.erlang.org/download/otp_src_18.3.tar.gz
+http://www.erlang.org/download/otp_src_19.3.tar.gz
+################################################################################
+### ICU4C
+http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.zip
+################################################################################
+### spidermonkey    js185-1.0.0.tar.gz
+http://ftp.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz
+################################################################################

--- a/downloads_32.md5
+++ b/downloads_32.md5
@@ -1,0 +1,9 @@
+89f15a9ef6b54bcba8d5bd9b9049d873 *curl-7.49.1.zip
+f797503ecaebf1d38920013dc7893066 *icu4c-57_1-src.zip
+a4574365938222adca0a6bd33329cb32 *js185-1.0.0.tar.gz
+7fbb850e4dd92b9905f5ab312bc39101 *js185-msvc2013.patch
+f85123cd390e864dfbe517e7616e6566 *openssl-1.0.2l.tar.gz
+346dd0136bf1cc28cebc140e505206bb *otp_src_17.5.tar.gz
+7e4ff32f97c36fb3dab736f8d481830b *otp_src_18.3.tar.gz
+a8c259ec47bf84e77510673e1b76b6db *otp_src_19.3.tar.gz
+0fc525b6b7b96a87523daa7a0013c69d *vcredist_x86.exe

--- a/installer/couchdb_32.wxs.in
+++ b/installer/couchdb_32.wxs.in
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Compile with:
+	>candle couchdb.wxs
+	>light -ext WixUIExtension -cultures:en-us couchdb.wixobj couchdbfiles.wixobj -out couchdb.msi
+-->
+<?define bitness = "(32 bit)" ?>
+<?define Win64 = "no" ?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+   xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+<!-- Substitute Version="####VERSION####" below and uncomment the
+     sed line in build_installer.cmd if we ever can guarantee numeric
+     version numbers. Until then, this must be manually updated per
+     release.
+-->
+	<Product Id="4CD776E0-FADF-4831-AF56-E80E39F34CFC"
+		Name="Apache CouchDB"
+		Language="1033"
+		Version="2.0.0.1"
+		Manufacturer="The Apache Software Foundation"
+		UpgradeCode="9449123B-61C4-40DE-AA6C-1BB9AA02EB67">
+
+		<Package InstallerVersion="405"
+			Compressed="yes" />
+		<Media Id="1"
+			Cabinet="media1.cab"
+			EmbedCab="yes" />
+
+        <!--Permissions-->
+        <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
+        <PropertyRef Id="WIX_ACCOUNT_USERS" />
+        <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
+
+		<!--Directory structure-->
+        <Property Id="ApplicationFolderName" Value="C:\CouchDB" />
+		<Directory Id="TARGETDIR"
+			Name="SourceDir">
+			<Directory Id="APPLICATIONFOLDER" Name="CouchDB">
+               <Component Id="AppFolder_comp" DiskId="1" Guid="C2C4462F-D9AE-4178-9E49-E2A85C256635">
+                  <CreateFolder>
+                     <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" />
+                     <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" />
+                     <Permission User="[WIX_ACCOUNT_USERS]" GenericRead="yes" GenericExecute="yes" />
+                  </CreateFolder>
+               </Component>
+            </Directory>
+			<Directory Id="ProgramMenuFolder">
+				<Directory Id="OurShortcutsDir" Name="Apache CouchDB" />
+			</Directory>
+		</Directory>
+
+		<DirectoryRef Id="TARGETDIR">
+    		<Merge Id="VCRedist120" SourceFile="C:\Program Files (x86)\Common Files\Merge Modules\Microsoft_VC120_CRT_x86.msm" DiskId="1" Language="0"/>
+		</DirectoryRef>
+		
+        <!--Icons-->
+        <Icon Id="couchdb.ico" SourceFile="..\bits\couchdb-64x64.ico" />
+        <Property Id="ARPPRODUCTICON" Value="couchdb.ico" />
+
+		<!--Start Menu Shortcuts-->
+		<DirectoryRef Id="OurShortcutsDir">
+			<Component Id="CMP_Shortcuts"
+				Guid="A2754FBF-3E43-4AEF-A70A-14D78CAC2784">
+
+				<Shortcut Id="DocumentationStartMenuShortcut"
+					Name="Apache CouchDB Documentation"
+					Description="Read the CouchDB Documentation"
+					Target="[APPLICATIONFOLDER]\share\www\docs\index.html" />
+
+				<util:InternetShortcut Id="FauxtonStartMenuShortcut"
+					Name="Apache CouchDB Fauxton" 
+                    Target="http://localhost:5984/_utils/index.html" />
+					
+				<Shortcut Id="ApplicationServiceMenuShortcut"
+                    Name="Start or Stop Apache CouchDB Service"
+					Description="Start or stop the Apache CouchDB service"
+                    Icon="couchdb.ico"
+                    Target="[SystemFolder]\services.msc" />
+					
+				<Shortcut Id="UninstallShortcut"
+					Name="Uninstall Apache CouchDB"
+					Description="Uninstalls Apache CouchDB"
+					Target="[SystemFolder]msiexec.exe"
+					Arguments="/x [ProductCode]" />
+					
+				<RemoveFolder Id="RemoveOurShortcutsDir"
+					On="uninstall" />
+				
+				<RegistryValue Root="HKCU"
+					Key="Software\Apache\CouchDB"
+					Name="installed"
+					Type="integer"
+					Value="1"
+					KeyPath="yes" />
+			</Component>
+		</DirectoryRef>
+		
+		<!--Features-->
+		<Feature Id="ProductFeature"
+			Title="Droplet"
+			Level="1">
+			<ComponentRef Id="CMP_Shortcuts" />
+            <ComponentRef Id="AppFolder_comp" />
+			<ComponentGroupRef Id="CouchDBFilesGroup" />
+		</Feature>
+		
+		<Feature Id="VCRedist120" Title="Visual C++ 12.0 Runtime" AllowAdvertise="no" Display="hidden" Level="1">
+    		<MergeRef Id="VCRedist120"/>
+		</Feature>
+		
+		<!--Custom actions and execute sequences-->
+	    <!-- Prevent downgrading -->
+	    <!-- <CustomAction Id="PreventDowngrading" After="FindRelatedProducts" Error="Newer version already installed." />  -->
+        <SetProperty 
+            Id="InstallCouchDBService"
+            Value="&quot;[APPLICATIONFOLDER]bin\nssm.exe&quot; install &quot;Apache CouchDB&quot; [APPLICATIONFOLDER]bin\couchdb.cmd"
+            Before="InstallCouchDBService"
+            Sequence="execute"
+        />
+        <CustomAction
+            Id="InstallCouchDBService"
+            BinaryKey="WixCA"
+            DllEntry="WixQuietExec"
+            Execute="deferred"
+            Return="ignore"
+            Impersonate="no"
+        />
+
+        <SetProperty
+            Id="StartCouchDBService"
+            Value="&quot;[APPLICATIONFOLDER]bin\nssm.exe&quot; start &quot;Apache CouchDB&quot;"
+            Before="StartCouchDBService"
+            Sequence="execute"
+        />
+        <CustomAction
+            Id="StartCouchDBService"
+            BinaryKey="WixCA"
+            DllEntry="WixQuietExec"
+            Execute="deferred"
+            Return="ignore"
+            Impersonate="no"
+        />
+
+        <SetProperty
+            Id="StopCouchDBService"
+            Value="&quot;[APPLICATIONFOLDER]bin\nssm.exe&quot; stop &quot;Apache CouchDB&quot;"
+            Before="StopCouchDBService"
+            Sequence="execute"
+        />
+        <CustomAction
+            Id="StopCouchDBService"
+            BinaryKey="WixCA"
+            DllEntry="WixQuietExec"
+            Execute="deferred"
+            Return="ignore"
+            Impersonate="no"
+        />
+
+        <SetProperty
+            Id="RemoveCouchDBService"
+            Value="&quot;[APPLICATIONFOLDER]bin\nssm.exe&quot; remove &quot;Apache CouchDB&quot; confirm"
+            Before="RemoveCouchDBService"
+            Sequence="execute"
+        />
+        <CustomAction
+            Id="RemoveCouchDBService"
+            BinaryKey="WixCA"
+            DllEntry="WixQuietExec"
+            Execute="deferred"
+            Return="ignore"
+            Impersonate="no"
+        />
+     
+        <!--Custom warning: no spaces in install path!-->
+        <Property Id="DirWarningText"
+           Value="Warning! Apache CouchDB must be installed into a path with no spaces. This installer will not prevent you from doing so, but the resulting installation will not work correctly." />
+        <UIRef Id="CouchDBWixUI" />
+		    
+		<!--Installer prefs-->
+        <WixVariable Id="WixUILicenseRtf" Value="LICENSE.rtf" />
+        <WixVariable Id="WixUIBannerBmp" Value="..\bits\couchdb-banner.bmp" />
+        <WixVariable Id="WixUIDialogBmp" Value="..\bits\couchdb-dialog.bmp" />
+		<Property Id="WIXUI_INSTALLDIR"
+			Value="APPLICATIONFOLDER" />
+		<Property Id="CA_EXCEPTION" Value="None" />
+		<Property Id="SCHEDULEREBOOT" Value="0" />
+        <InstallExecuteSequence>
+           <Custom Action="InstallCouchDBService" After="InstallFiles" />
+           <Custom Action="StartCouchDBService" After="InstallCouchDBService" />
+           <Custom Action="StopCouchDBService" After="MsiUnpublishAssemblies" >
+              Installed AND (REMOVE = "ALL")
+           </Custom>
+           <Custom Action="RemoveCouchDBService" After="StopCouchDBService" >
+              Installed AND (REMOVE = "ALL")
+           </Custom>
+        </InstallExecuteSequence>
+	</Product>
+</Wix>
+


### PR DESCRIPTION
I had to build a 32bit version of CouchDB on Windows. 

I mixed the current configuration scripts with 1.7.1 instructions and was able to compile a 32bit version.

As I found this very complicated, I want to share the work done with people.

I'm not sure if we want to keep that in a separate branch or simply keep those file in the main branch.

Since the 32bit version will not be supported, maybe I should make it more explicit that users must use it at their own risk?

