### PR TITLE
Transform heat output to make local.ini permanent

### DIFF
--- a/bin/build_installer.cmd
+++ b/bin/build_installer.cmd
@@ -59,7 +59,7 @@ echo New Log >%COUCHDB%\var\log\couchdb.log
 :: we'd want to manually merge. heat will regenerate all GUIDS and that will
 :: cause problems in the field if we ever start upgrading rather than
 :: uninstall/reinstall. It's the -gg flag that results in this behaviour.
-heat dir %COUCHDB% -dr APPLICATIONFOLDER -cg CouchDBFilesGroup -gg -g1 -sfrag -srd -sw5150 -var "var.CouchDir" -out couchdbfiles.wxs
+heat dir %COUCHDB% -dr APPLICATIONFOLDER -cg CouchDBFilesGroup -gg -g1 -sfrag -srd -sw5150 -var "var.CouchDir" -t heat-filter.xslt -out couchdbfiles.wxs
 
 :: Build MSI for installation
 candle -arch x64 -ext WiXUtilExtension couchdb.wxs

--- a/bin/heat-filter.xslt
+++ b/bin/heat-filter.xslt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://schemas.microsoft.com/wix/2006/wi"
+    xmlns:wix="http://schemas.microsoft.com/wix/2006/wi"
+    xmlns:msxsl="urn:schemas-microsoft-com:xslt" exclude-result-prefixes="msxsl">
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <!-- Set up keys for matchin certain elements -->
+  <xsl:key name="local-ini-file" match="wix:Component[contains(wix:File/@Source, '\etc\local.ini')]" use="@Id"/>
+
+  <!-- Identity Transform  (Copy everything)-->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Match the local.ini file -->
+  <xsl:template match="wix:Component[key('local-ini-file', @Id)]">
+     <xsl:copy>
+     <!-- Set the Permanent attribute to yes-->
+      <xsl:attribute name="Permanent">
+         <xsl:text>yes</xsl:text>
+      </xsl:attribute>
+      
+      <!-- Set the NeverOverwrite to yes -->
+      <xsl:attribute name="NeverOverwrite">
+         <xsl:text>yes</xsl:text>
+      </xsl:attribute>
+
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
When uninstalling CouchDB, configurations are currently "lost" unless they were manually created.

This pull request ensure that:

- etc/local.ini is permanent
- etc/local.ini will not be overwritten

As for local.d, since files in this folder are manually created, they won't be uninstalled by the installer.

Tested on Windows 10 64bit (using a custom build chain for 32bit version)