### PR TITLE
.Net 3 -> 4

### DIFF
--- a/installer/CustomAction/CustomAction.config
+++ b/installer/CustomAction/CustomAction.config
@@ -7,6 +7,6 @@
  -->
   <configuration>
      <startup useLegacyV2RuntimeActivationPolicy="true">
-        <supportedRuntime version="v2.0.50727" />
+        <supportedRuntime version="v4.0" />
      </startup>
   </configuration>

--- a/installer/CustomAction/CustomAction.csproj
+++ b/installer/CustomAction/CustomAction.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomAction</RootNamespace>
     <AssemblyName>CouchIniAction</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">C:\Program Files (x86)\MSBuild\Microsoft\WiX\v3.x\wix.ca.targets</WixCATargetsPath>
   </PropertyGroup>


### PR DESCRIPTION
The status of [supportedRuntime](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/startup/supportedruntime-element) and [TargetFrameworkVersion](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-target-framework-and-target-platform) are rather confusing. In theory using the lowest version of TargetFrameworkVersion that could be in use would probably be best but I think building with a supported version means forcing an upgrade for anyone using something earlier than the [supported versions](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).

In my testing using v4.0 for both and not setting any specific sku seems to be working which should cover any OS not long EOLed.
