### PR TITLE
Fix FIPS compliance in CouchIniAction.cs

### DIFF
--- a/installer/CustomAction/CouchIniAction.cs
+++ b/installer/CustomAction/CouchIniAction.cs
@@ -187,7 +187,7 @@ namespace CustomAction
         {
             using (FileStream stream = File.OpenRead(file))
             {
-                SHA256Managed sha = new SHA256Managed();
+                SHA256CryptoServiceProvider sha = new SHA256CryptoServiceProvider();
                 byte[] checksum = sha.ComputeHash(stream);
                 return BitConverter.ToString(checksum).Replace("-", String.Empty);
             }


### PR DESCRIPTION
CouchIniAction.cs used the non-FIPS compliant managed SHA256 implementation, which caused an exception to be thrown during uninstall. This change replaces that call with the FIPS compliant SHA256CryptoServiceProvider.