### PR TITLE
docs: document `mach create-mach-enviroment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Now you should be set to launch the build.
 
 ```bash
 export MOZCONFIG=/c/relax/couchdb-glazier/moz/sm-opt
+./mach create-mach-environment
 ./mach build
 exit
 ```


### PR DESCRIPTION
The `create-match-environment` command is not discussed as part of the installation procedure while it might be needed when working with a completely fresh install.  This is not done automatically, though the user is going to be told to do that.