### PR TITLE
chore: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ git clone https://github.com/apache/couchdb-glazier
 
 You should go get lunch. The last step will take over an hour, even on a speedy Internet connection.
 
-At this point, you should have the following installed:
+You're finally ready.  You should have the following installed:
 
 * Visual Studio 2022 (Build Tools, Visual C++ workload, native desktop workload)
 * Windows 10 SDK (by native desktop workload; 10.0.19041.0)
 * NodeJS (LTS version)
-* WiX Toolset
+* WiX Toolset 3.11
 * Python 3
   * Python packages sphinx, sphinx_rtd_theme, pygments, nose2 and hypothesis
 * NSSM
@@ -55,80 +55,14 @@ At this point, you should have the following installed:
 * VSSetup
 * VSWhere
 * GNU CoreUtils (cp, rm, rmdir, ...)
-* MozillaBuild setup
 * VCPkg (https://github.com/Microsoft/vcpkg), which built and installed:
   * ICU (at time of writing, 69.1)
+  * OpenSSL 3
+* SpiderMonkey 91
 
-# Building SpiderMonkey
-
-This section is not currently automated, due to the need for Mozilla's separate build
-environment. It should be possible to automate (PRs welcome!). At time of writing, we
-use the `esr91` branch of SpiderMonkey.
-
-From the same PowerShell prompt, enter the following:
-
-```powershell
-C:\mozilla-build\start-shell.bat
-```
-
-At the MozillaBuild prompt, enter the following:
-
-```bash
-cd /c/relax
-git clone https://github.com/mozilla/gecko-dev
-cd gecko-dev
-./mach bootstrap --application-choice js
-git checkout esr91
-```
-
-Please answer the following questions of `./mach boostrap`.  Note that some of them may not show
-up. You need this only for the first run. It downloads a complete build toolchain for
-SpiderMonkey. You should run `./mach bootstrap` from the `master` branch and switch afterwards
-to your explicit ESR branch!
-
-* Would you like to create this directory? (Yn): Y
-* Would you like to run a few configuration steps to ensure Git is optimally configured? (Yn): Y
-* Will you be submitting commits to Mozilla? (Yn): n
-* Would you like to enable build system telemetry? (Yn): n
-
-On completely fresh Windows installs, it may happen that the necessary SSL certificates
-are not yet stored on the system. This can cause that some of the files cannot be
-downloaded over HTTPS. Open the URL https://static.rust-lang.org/ on Internet Explorer
-and install the missing certificate to resolve this.
-
-The build process may complain about clobbering (perhaps due to switching off from `master`).
-In this case, create the `CLOBBER` file to silence the related warnings.
-
-Now you should be set to launch the build.
-
-```bash
-export MOZCONFIG=/c/relax/couchdb-glazier/moz/sm-opt
-./mach create-mach-environment
-./mach build
-exit
-```
-
-Once finished, you should have built SpiderMonkey.
-Back in PowerShell, copy the binaries to where our build process expects them:
-
-```powershell
-copy C:\relax\gecko-dev\sm-obj-opt\js\src\build\*.lib C:\relax\vcpkg\installed\x64-windows\lib
-copy C:\relax\gecko-dev\sm-obj-opt\dist\bin\*.dll C:\relax\vcpkg\installed\x64-windows\bin
-copy C:\relax\gecko-dev\sm-obj-opt\dist\include\* C:\relax\vcpkg\installed\x64-windows\include -Recurse -ErrorAction SilentlyContinue
-```
-
-Be sure to verify if all the components are built properly, especially the static library,
-i.e. `mozjs-91.lib`, otherwise CouchDB will fail to build. In case anything is missing,
-check the logs for errors and try searching for them on the [Mozilla Bug Tracker](https://bugzilla.mozilla.org/home).
-
-Currently known problems:
-
-- [lld-link: error: duplicate symbol: HeapAlloc](https://bugzilla.mozilla.org/show_bug.cgi?id=1802675)
-- [JS shell build with --disable-jemalloc hits linker error with 2 DllMain](https://bugzilla.mozilla.org/show_bug.cgi?id=1751561)
+You should snapshot your VM at this point.
 
 # Building CouchDB itself
-
-You're finally ready. You should snapshot your VM at this point!
 
 Open a new PowerShell window. Set up your shell correctly (this step works if you've
 closed your PowerShell window before any of the previous steps, too):

--- a/bin/install_dependencies.ps1
+++ b/bin/install_dependencies.ps1
@@ -19,9 +19,11 @@ Add-MpPreference -ExclusionPath "C:\relax"
 # Install build tools - requires English language pack installed
 choco install visualstudio2022buildtools "--passive --locale en-US"
 choco install visualstudio2022-workload-vctools --package-parameters "--add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.Redist.MSM --add Microsoft.Net.Component.4.8.TargetingPack"
-choco install wixtoolset make nssm vswhere gnuwin32-coreutils.portable
+choco install make nssm vswhere gnuwin32-coreutils.portable
+choco install wixtoolset --version=3.11.2
 choco install nodejs --version=16.19.0
 choco install python --version=3.10.8
+choco install archiver --version=3.1.0
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module VSSetup -Scope CurrentUser -Force
 
@@ -38,14 +40,7 @@ pip install --upgrade sphinx sphinxcontrib-httpdomain sphinx_rtd_theme pygments 
 # Hide the Download-StatusBar and improve download speed of wget-Cmdlet
 $ProgressPreference = 'SilentlyContinue'
 
-# Download and install MozillaBuild environment
-# DON'T USE MozillaBuild 4.0. At time of writing, it fails even to start building sm
-Write-Output "Downloading MozillaBuild ..."
-Invoke-WebRequest -Uri $mozBuildUri -OutFile $mozBuildFile
-Write-Output "Installing MozillaBuild ..."
-Start-Process -Wait -Filepath "$mozBuildFile" -ArgumentList "/S"
-
-# Download and install Erlang/OTP 23
+# Download and install Erlang/OTP 24
 Write-Output "Downloading Erlang ..."
 Invoke-WebRequest -Uri $erlBuildUri -OutFile $erlBuildFile
 Write-Output "Installing Erlang ..."
@@ -65,7 +60,27 @@ Write-Output "Installing VCPkg ..."
 .\bootstrap-vcpkg.bat -disableMetrics
 .\vcpkg integrate install --triplet x64-windows
 .\vcpkg install icu --triplet x64-windows
+.\vcpkg install openssl --triplet x64-windows
 Set-Location ..
+
+# Download and install SpiderMonkey
+Write-Output "Downloading SpiderMonkey ..."
+Invoke-WebRequest -Uri $smBuildUri -OutFile $smBuildFile
+Write-Output "Installing SpiderMonkey ..."
+arc unarchive $smBuildFile
+copy -Recurse -Force "$smBuild\*" .\vcpkg\installed\x64-windows\
+
+# Download and install Java 8
+Write-Output "Downloading OpenJDK 8 ..."
+Invoke-WebRequest -Uri $java8BuildUri -OutFile $java8BuildFile
+Write-Output "Installing OpenJDK 8 ..."
+arc unarchive $java8BuildFile "C:\tools"
+
+# Download and install Java 11
+Write-Output "Downloading OpenJDK 11 ..."
+Invoke-WebRequest -Uri $java11BuildUri -OutFile $java11BuildFile
+Write-Output "Installing OpenJDK 11 ..."
+arc unarchive $java11BuildFile "C:\tools"
 
 # we know what we are doing (, do we really?)
 Set-ExecutionPolicy Bypass -Scope CurrentUser -Force

--- a/bin/shell.ps1
+++ b/bin/shell.ps1
@@ -29,12 +29,14 @@ Import-Module ${PSScriptRoot}\which.psm1
 
 $env:VCPKG_BIN = "C:\relax\vcpkg\installed\x64-windows\bin"
 $env:PATH += ";${erlInstallPath}\bin"
-$env:PATH += ";${elxInstallPath}\bin" 
+$env:PATH += ";${elxInstallPath}\bin"
 $env:PATH += ";C:\relax\vcpkg\installed\x64-windows\bin"
 $env:PATH += ";C:\Program Files (x86)\WiX Toolset v3.11\bin"
+$env:PATH += ";C:\tools\${java11Build}\bin"
 
 $env:LIB = "C:\relax\vcpkg\installed\x64-windows\lib;" + $env:LIB
 $env:INCLUDE = "C:\relax\vcpkg\installed\x64-windows\include;" + $env:INCLUDE
 $env:LIBPATH = "C:\relax\vcpkg\installed\x64-windows\lib;" + $env:LIBPATH
 
-
+$env:JAVA_HOME = "C:\tools\${java11Build}"
+$env:CLOUSEAU_JAVA_HOME = "C:\tools\${java8Build}"

--- a/bin/variables.ps1
+++ b/bin/variables.ps1
@@ -10,16 +10,10 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# MOZILLA BUILD SETTINGS
-
-# Download location of the Mozilla Build Environment for Windows
-$mozBuildUri = "https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.4.exe"
-$mozBuildFile = Split-Path $mozBuildUri -Leaf
-
 # ERLANG BUILD SETTINGS
 
 # Download location of the Erlang/OTP Environment for Windows (x64)
-$erlVersion = "24.3.4.8"
+$erlVersion = "24.3.4.14"
 $erlBuildUri = "https://github.com/erlang/otp/releases/download/OTP-${erlVersion}/otp_win64_${erlVersion}.exe"
 $erlBuildFile = Split-Path $erlBuildUri -Leaf
 $erlDir = "erl-${erlVersion}"
@@ -27,7 +21,29 @@ $erlInstallPath = "C:\tools\${erlDir}"
 
 # ERLANG BUILD SETTINGS
 
-# Download location of the Elixier binaries for Windows (x64)
-$elxBuildUri = "https://github.com/elixir-lang/elixir/releases/download/v1.13.4/Precompiled.zip"
+# Download location of the Elixir binaries for Windows (x64)
+$elxBuildUri = "https://github.com/elixir-lang/elixir/releases/download/v1.15.7/elixir-otp-24.zip"
 $elxBuildFile = Split-Path $elxBuildUri -Leaf
 $elxInstallPath = "C:\relax\elixir"
+
+# SPIDERMONKEY SETTINGS
+
+# Donwload location of the SpiderMonkey development files for Windows (x64)
+$smBuild = "Windows-mozjs-91"
+$smBuildUri = "https://github.com/big-r81/couchdb-sm/releases/download/v0.0.3/$smBuild.tar.xz"
+$smBuildFile = Split-Path $smBuildUri -Leaf
+$smInstallPath = "C:\relax\vcpkg\installed\x64-windows"
+
+# JAVA 8 SETTINGS
+
+# Donwload location of OpenJDK 8 for Windows (x64)
+$java8Build = "zulu8.74.0.17-ca-jre8.0.392-win_x64"
+$java8BuildUri = "https://cdn.azul.com/zulu/bin/$java8Build.zip"
+$java8BuildFile = Split-Path $java8BuildUri -Leaf
+
+# JAVA 11 SETTINGS
+
+# Donwload location of OpenJDK 11 for Windows (x64)
+$java11Build = "zulu11.68.17-ca-jre11.0.21-win_x64"
+$java11BuildUri = "https://cdn.azul.com/zulu/bin/$java11Build.zip"
+$java11BuildFile = Split-Path $java11BuildUri -Leaf


### PR DESCRIPTION
- Bump Erlang to 24.3.4.14
- Bump Elixir to 1.15.6
- Install OpenSSL 3
- Replace MozBuild for a [pre-built SpiderMonkey 91 distribution](https://github.com/big-r81/couchdb-sm) (thanks to @big-r81)
- Add OpenJDK 8 for Clouseau
- Add OpenJDK 11 for Nouveau
- Pin WiX Toolset version to 3.11.2
