### PR TITLE
chore: clean up installation and use of Vcpkg

### DIFF
--- a/bin/install_dependencies.ps1
+++ b/bin/install_dependencies.ps1
@@ -54,21 +54,26 @@ Expand-Archive -Path $elxBuildFile -DestinationPath $elxInstallPath
 
 # Download and install VCPkg
 Write-Output "Downloading VCPkg ..."
-git clone https://github.com/Microsoft/vcpkg.git
-Set-Location vcpkg
+Invoke-WebRequest -Uri $vcpkgUri -OutFile $vcpkgFile
 Write-Output "Installing VCPkg ..."
-.\bootstrap-vcpkg.bat -disableMetrics
-.\vcpkg integrate install --triplet x64-windows
-.\vcpkg install icu --triplet x64-windows
-.\vcpkg install openssl --triplet x64-windows
-Set-Location ..
+arc unarchive $vcpkgFile
+copy -Recurse -Force "vcpkg-${vcpkgVersion}" $vcpkgInstallPath
+& "${vcpkgInstallPath}\bootstrap-vcpkg.bat" -disableMetrics
+$vcpkg = "${vcpkgInstallPath}\vcpkg"
+& $vcpkg integrate install --triplet x64-windows
+
+Write-Output "Installing ICU ..."
+& $vcpkg install icu --triplet x64-windows
+
+Write-Output "Installing OpenSSL ..."
+& $vcpkg install openssl --triplet x64-windows
 
 # Download and install SpiderMonkey
 Write-Output "Downloading SpiderMonkey ..."
 Invoke-WebRequest -Uri $smBuildUri -OutFile $smBuildFile
 Write-Output "Installing SpiderMonkey ..."
 arc unarchive $smBuildFile
-copy -Recurse -Force "$smBuild\*" .\vcpkg\installed\x64-windows\
+copy -Recurse -Force "$smBuild\*" $vcpkgBase
 
 # Download and install Java 8
 Write-Output "Downloading OpenJDK 8 ..."

--- a/bin/shell.ps1
+++ b/bin/shell.ps1
@@ -27,16 +27,16 @@ if ($installationPath -and (test-path "$installationPath\Common7\Tools\vsdevcmd.
 }
 Import-Module ${PSScriptRoot}\which.psm1
 
-$env:VCPKG_BIN = "C:\relax\vcpkg\installed\x64-windows\bin"
+$env:VCPKG_BIN = "${vcpkgBase}\bin"
 $env:PATH += ";${erlInstallPath}\bin"
 $env:PATH += ";${elxInstallPath}\bin"
-$env:PATH += ";C:\relax\vcpkg\installed\x64-windows\bin"
+$env:PATH += ";${vcpkgBase}\bin"
 $env:PATH += ";C:\Program Files (x86)\WiX Toolset v3.11\bin"
 $env:PATH += ";C:\tools\${java11Build}\bin"
 
-$env:LIB = "C:\relax\vcpkg\installed\x64-windows\lib;" + $env:LIB
-$env:INCLUDE = "C:\relax\vcpkg\installed\x64-windows\include;" + $env:INCLUDE
-$env:LIBPATH = "C:\relax\vcpkg\installed\x64-windows\lib;" + $env:LIBPATH
+$env:LIB = "${vcpkgBase}\lib;" + $env:LIB
+$env:INCLUDE = "${vcpkgBase}\include;" + $env:INCLUDE
+$env:LIBPATH = "${vcpkgBase}\lib;" + $env:LIBPATH
 
 $env:JAVA_HOME = "C:\tools\${java11Build}"
 $env:CLOUSEAU_JAVA_HOME = "C:\tools\${java8Build}"

--- a/bin/variables.ps1
+++ b/bin/variables.ps1
@@ -10,6 +10,15 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# VCPKG SETTINGS
+
+# Download location of Vcpkg for Windows
+$vcpkgVersion = "2023.10.19"
+$vcpkgUri = "https://github.com/microsoft/vcpkg/archive/refs/tags/${vcpkgVersion}.zip"
+$vcpkgFile = Split-Path $vcpkgUri -Leaf
+$vcpkgInstallPath = "C:\tools\vcpkg"
+$vcpkgBase = "${vcpkgInstallPath}\installed\x64-windows"
+
 # ERLANG BUILD SETTINGS
 
 # Download location of the Erlang/OTP Environment for Windows (x64)


### PR DESCRIPTION
Clean up the invocations of the [Vcpkg](https://github.com/microsoft/vcpkg) tool: place it under `C:\tools\vcpkg` and pin its version to 2023.10.19.