### PR TITLE
Extract CouchDB version from `version.mk`

### DIFF
--- a/bin/build_installer.ps1
+++ b/bin/build_installer.ps1
@@ -34,8 +34,9 @@ if (! $env:VCPKG_BIN)
 }
 
 $Glazier = "${PSScriptRoot}\.."
-$CouchDBVersion = Get-Content "${CouchDB}\releases\start_erl.data" |
-      ForEach-Object {$_.Split(" ")[1]}
+$VersionMK = Get-Content -Path "$CouchDB_Root\version.mk" | Out-String | ConvertFrom-StringData
+
+$CouchDBVersion = $VersionMK.vsn_major,$VersionMK.vsn_minor,$VersionMK.vsn_patch -join "."
 $RelNotesVersion = $CouchDBVersion -replace "^(\d+\.\d+)\..*", '$1'
 
 # clean up from previous runs


### PR DESCRIPTION
The CouchDB version was extracted from the `rel/couchdb/releases/start_erl.data` file. This version string was removed in [1,2].

Since we have a file (`version.mk`) with the released CouchDB version, use this and extract the number from here.

[1] https://github.com/apache/couchdb/pull/5085
[2] https://github.com/apache/couchdb/pull/5078