### PR TITLE
Helper scripts for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You're finally ready.  You should have the following installed:
 * VSSetup
 * VSWhere
 * GNU CoreUtils (cp, rm, rmdir, ...)
+* MSYS2 (for building QuickJS)
+* Java (for building Nouveau)
 * VCPkg (https://github.com/Microsoft/vcpkg), which built and installed:
   * ICU
   * OpenSSL 3
@@ -97,8 +99,24 @@ The installer will be placed in your current working directory.
 
 You made it! Time to relax. :D
 
-If you're a release engineer, you may find the following commands useful too:
+If you're a release engineer, the script `download_extract_rc.ps1` in
+the `bin\` directory helps you to download, check and extract a 
+CouchDB source tarball.
 
+```
+SYNTAX
+    C:\relax\couchdb-glazier\bin\download_extract_rc.ps1 [[-CouchDBVersion] <String>] [[-ReleaseCandidate] <String>] [[-Path] <String>] [<CommonParameters>]
+
+    
+DESCRIPTION
+    This command downloads, checks and extract a CouchDB source tarball
+
+    -CouchDBVersion <string>        CouchDB version number to download (e.g. 3.4.2)
+    -ReleaseCandidate <string>      Release candidate version number (e.g. rc1)
+    -Path <string>                  Directory to store the artifacts (e.g. C:\relax\releases)
+```
+
+To checksum a source tarball, you may find the following commands useful too:
 ```
 checksum -t sha256 apache-couchdb.#.#.#-RC#.tar.gz
 checksum -t sha512 apache-couchdb.#.#.#-RC#.tar.gz

--- a/bin/download_extract_rc.ps1
+++ b/bin/download_extract_rc.ps1
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+
+# Helper script for lazy Windows Developers
+# Downloading, checking and extracting the sources of a rc candidate for Windows
+
+<#
+.SYNOPSIS
+    Little helper script for lazy Windows (Release) Developers
+.DESCRIPTION
+    This command downloads, checks and extract a CouchDB source tarball
+
+    -CouchDBVersion <string>        CouchDB version number to download (e.g. 3.4.2)
+    -ReleaseCandidate <string>      Release candidate version number (e.g. rc1)
+    -Path <string>                  Directory to store the artifacts (e.g. C:\relax\releases)
+
+.LINK
+    https://couchdb.apache.org/
+#>
+
+[CmdletBinding()]
+param(
+   [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+   [ValidateNotNullOrEmpty()]
+   [String]$CouchDBVersion,
+
+   [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+   [ValidateNotNullOrEmpty()]
+   [String]$ReleaseCandidate,
+
+   [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+   [ValidateNotNullOrEmpty()]
+   [String]$Path
+)
+
+$DOWNLOAD_URL = "https://dist.apache.org/repos/dist/dev/couchdb/source/$CouchDBVersion/$ReleaseCandidate/"
+$DOWNLOAD_DIR = Join-Path (Join-Path $Path $CouchDBVersion) $ReleaseCandidate
+
+# start shell
+. ${PSScriptRoot}\shell.ps1
+
+if(Test-Path -Path $DOWNLOAD_DIR) {
+    Remove-Item -Path $DOWNLOAD_DIR -Recurse -Force
+}
+New-Item -ItemType Directory -Path $DOWNLOAD_DIR
+
+# Download tarball and checksums
+$ProgressPreference = "SilentlyContinue"
+Write-Output "####### DOWNLOAD SOURCES ########"
+$fileList = Invoke-WebRequest $DOWNLOAD_URL -UseBasicParsing
+$fileNames = $($fileList.Links |?{$_.href -match "apache-couchdb"}).href
+foreach ($file in $fileNames)
+{
+    Write-Output $DOWNLOAD_URL$file
+    Invoke-WebRequest -Uri "$DOWNLOAD_URL$file" -OutFile $(Join-Path $DOWNLOAD_DIR $file)
+}
+Write-Output "#################################`n`n"
+
+# Used Software for compiling CouchDB
+Write-Output "####### SOFTWARE VERSIONS #######"
+erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+elixir --version
+python --version
+java -version
+Write-Output "#################################`n`n"
+
+# Check signature and checksum
+Write-Output "######## CHECK SIGNATURE ########"
+C:\tools\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -where $DOWNLOAD_DIR -c "curl -s -L https://apache.org/dist/couchdb/KEYS | gpg --import -"
+C:\tools\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -where $DOWNLOAD_DIR -c "gpg --verify apache-couchdb-*.tar.gz.asc"
+C:\tools\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -where $DOWNLOAD_DIR -c "sha256sum --check apache-couchdb-*.tar.gz.sha256"
+Write-Output "#################################`n`n"
+
+# Extract sources
+Write-Output "######## EXTRACT SORUCES ########"
+arc unarchive $(Join-Path $DOWNLOAD_DIR "apache-couchdb-*.tar.gz" -Resolve) "$DOWNLOAD_DIR"
+Write-Output "#################################`n`n"
+
+Set-Location "$DOWNLOAD_DIR\apache-couchdb-$CouchDBVersion"

--- a/bin/exclude_tests_win.ps1
+++ b/bin/exclude_tests_win.ps1
@@ -1,0 +1,72 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+
+# Helper script for excluding some tests which fail under Windows
+# see https://github.com/apache/couchdb/issues/4398
+
+
+<#
+.SYNOPSIS
+    Little helper script to exclude some CouchDB before doing a "make check"
+
+.DESCRIPTION
+    This command renames some test files to get excluded/included from running tests
+
+    -IncludeTests       Include already excluded tests for the next test run
+    -Path <string>      Path to the CouchDB source tree directory
+
+.LINK
+    https://couchdb.apache.org/
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+
+    [switch]$IncludeTests = $false     #include tests again
+)
+
+$excludeTests = @(
+    "src\couch\test\eunit\couchdb_attachments_tests.erl",
+    "src\chttpd\test\eunit\chttpd_db_test.erl",
+    "src\chttpd\test\eunit\chttpd_dbs_info_test.erl",
+    "src\chttpd\test\eunit\chttpd_security_tests.erl",
+    "src\chttpd\test\eunit\chttpd_socket_buffer_size_test.erl",
+    "src\chttpd\test\eunit\chttpd_socket_buffer_size_test.erl"
+)
+
+function renameFile ([string]$file, [bool]$exclude = $true) {
+    if($exclude) {
+        if( Test-Path -path $file ) {
+            Write-Host "$file is excluded during testing..."
+            Rename-Item -path $file -NewName "$file.old"
+        }  
+    } else {
+        if( Test-Path -path "$file.old" ) {
+            Write-Host "$file is considered during testing..."
+            Rename-Item -path "$file.old" -NewName "$file"
+        }
+    }
+}
+
+foreach ($test in $excludeTests)
+{
+    $file = Join-Path $Path $test
+    if($IncludeTests) {
+        renameFile $file $false
+    } else {
+        renameFile $file $true
+    }
+}


### PR DESCRIPTION
Adding two helper scripts for Windows:

- `download_extract_rc.ps1` doing the boring and repetitive work when testing a release. Downloads, checks and extract the source tarball
- `exclude-tests-win.ps1` can be run to exclude some tests before running `make check`