### PR TITLE
chore(dev): Bump dependencies and signing provider

### DIFF
--- a/bin/sign_msi_ssl_dot_com.ps1
+++ b/bin/sign_msi_ssl_dot_com.ps1
@@ -22,13 +22,14 @@ Param(
     [string]$MSIFile
     )
 
-# EDIT BOTH VARIABLES ###################################################
-$Storepass = '<api-key>"|"<path-to-client-cert>"|"<client-cert-password>'
-$Alias = "<your-digicert-alias>"
+# EDIT ALL VARIABLES ####################################################
+$Storepass = '"<ssl.com user name>|<ssl.com password>"'
+$Alias = '<your-alias>'
+$Keypass = '<ssl.com eSigner TOTP secret>'
 #########################################################################
 
 # RFC 3161 timestamping URL
-New-Variable -Name TSAUrl -Value "http://timestamp.digicert.com" -Option Constant
+New-Variable -Name TSAUrl -Value "http://ts.ssl.com" -Option Constant
 
 # call JSign and sign file
-jsign --storetype DIGICERTONE --storepass $Storepass --alias $Alias --tsaurl $TSAUrl $MSIFile
+jsign --storetype ESIGNER --alias $Alias --storepass $Storepass --keypass $Keypass --tsaurl $TSAUrl --tsmode RFC3161 --alg SHA256 $MSIFile

--- a/bin/variables.ps1
+++ b/bin/variables.ps1
@@ -44,8 +44,8 @@ $elxInstallPath = "${toolsDir}\${elxDir}"
 # SPIDERMONKEY SETTINGS
 
 # Download location of the pre-build SpiderMonkey development files for Windows (x64)
-$smBuild = "Windows-mozjs-91"
-$smBuildVersion = "0.0.6"
+$smBuild = "Windows-mozjs-128"
+$smBuildVersion = "0.0.9"
 $smBuildUri = "https://github.com/big-r81/couchdb-sm/releases/download/v${smBuildVersion}/${smBuild}.tar.xz"
 $smBuildFile = "${artifactDir}\$(Split-Path $smBuildUri -Leaf)"
 $smInstallPath = "${toolsDir}\${smBuild}"
@@ -53,13 +53,13 @@ $smInstallPath = "${toolsDir}\${smBuild}"
 # JAVA 8 SETTINGS
 
 # Donwload location of OpenJDK 8 for Windows (x64)
-$java8Build = "zulu8.80.0.17-ca-jdk8.0.422-win_x64"
+$java8Build = "zulu8.82.0.21-ca-jdk8.0.432-win_x64"
 $java8BuildUri = "https://cdn.azul.com/zulu/bin/$java8Build.zip"
 $java8BuildFile = "${artifactDir}\$(Split-Path $java8BuildUri -Leaf)"
 
 # JAVA 21 SETTINGS
 
 # Donwload location of OpenJDK 21 for Windows (x64)
-$java21Build = "zulu21.36.17-ca-jdk21.0.4-win_x64"
+$java21Build = "zulu21.38.21-ca-jdk21.0.5-win_x64"
 $java21BuildUri = "https://cdn.azul.com/zulu/bin/$java21Build.zip"
 $java21BuildFile = "${artifactDir}\$(Split-Path $java21BuildUri -Leaf)"


### PR DESCRIPTION
- Bump Java v(8/21)
- Bump Spidermonkey v128
- Change msi signing from DigiCert to SSL.com