### PR TITLE
Improve git sha detection

### DIFF
--- a/bin/build_installer.ps1
+++ b/bin/build_installer.ps1
@@ -66,6 +66,7 @@ $Glazier = "${PSScriptRoot}\.."
 $VersionMK = Get-Content -Path "$CouchDB_Root\version.mk" | Out-String | ConvertFrom-StringData
 
 $CouchDBVersion = $VersionMK.vsn_major,$VersionMK.vsn_minor,$VersionMK.vsn_patch -join "."
+$CouchDBDistGitSha = $VersionMK.git_sha
 $RelNotesVersion = $CouchDBVersion -replace "^(\d+\.\d+)\..*", '$1'
 
 # clean up from previous runs
@@ -124,6 +125,10 @@ Move-Item -Path "${CouchDB}\etc\vm.args.dist" -Destination "${CouchDB}\etc\vm.ar
 Move-Item -Path "${Glazier}\installer\apache-couchdb-${CouchDBVersion}.msi" -Destination "." -Force
 
 if($IncludeGitSha) {
-   $GitSha = (git rev-parse --short HEAD)
-   Rename-Item -Path "apache-couchdb-${CouchDBVersion}.msi" -NewName "apache-couchdb-${CouchDBVersion}-${GitSha}.msi"
+   $GitSha = & git rev-parse --short HEAD 2>$null
+   if ($GitSha.Length -gt 0) { # Fetch git sha from git directory itself
+      Rename-Item -Path "apache-couchdb-${CouchDBVersion}.msi" -NewName "apache-couchdb-${CouchDBVersion}-${GitSha}.msi"
+   } elseif ($CouchDBDistGitSha -gt 0) { # Fetch git sha from version.mk within dist directory
+      Rename-Item -Path "apache-couchdb-${CouchDBVersion}.msi" -NewName "apache-couchdb-${CouchDBVersion}-${CouchDBDistGitSha}.msi"
+   }
 }


### PR DESCRIPTION
If used with command param -IncludeGitSha, get the sha from the git directory (if available) or from the version.mk file from a dist zip.