### PR TITLE
chore(`dev`): enable auto-deletion of branches upon merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,7 @@ github:
     - powershell
   features:
     issues: true
+  del_branch_on_merge: true
   protected_branches:
     main:
       required_status_checks:


### PR DESCRIPTION
Let us have branches deleted automatically once the pull request opened for them has been merged into the default branch (`main`).  This is about extending [`apache/couchdb` #5388](https://github.com/apache/couchdb/pull/5388) to this repository.