### PR TITLE
Remove Java 8 with the deprecation of Clouseau 2.x

### DIFF
--- a/bin/install_dependencies.ps1
+++ b/bin/install_dependencies.ps1
@@ -89,12 +89,6 @@ Invoke-WebRequest -Uri $smBuildUri -OutFile $smBuildFile
 Write-Output "Installing SpiderMonkey ..."
 arc unarchive $smBuildFile $toolsDir
 
-# Download and install Java 8
-Write-Output "Downloading OpenJDK 8 ..."
-Invoke-WebRequest -Uri $java8BuildUri -OutFile $java8BuildFile
-Write-Output "Installing OpenJDK 8 ..."
-arc unarchive $java8BuildFile "${toolsDir}"
-
 # Download and install Java 21
 Write-Output "Downloading OpenJDK 21 ..."
 Invoke-WebRequest -Uri $java21BuildUri -OutFile $java21BuildFile

--- a/bin/shell.ps1
+++ b/bin/shell.ps1
@@ -45,5 +45,8 @@ $env:LIBPATH = "${vcpkgBase}\lib;${smInstallPath}\lib;" + $env:LIBPATH
 $env:JAVA_HOME = "${toolsDir}\${java21Build}"
 $env:PATH += ";${env:JAVA_HOME}\bin"
 
-# Needed for Closeau
-$env:CLOUSEAU_JAVA_HOME = "${toolsDir}\${java8Build}"
+# Needed for Closeau:
+# This is the same as for Nouveau for the moment, but perhaps it is better to
+# keep it separate as there is no guarantee that they will be bumped at the
+# same pace.
+$env:CLOUSEAU_JAVA_HOME = "${toolsDir}\${java21Build}"

--- a/bin/variables.ps1
+++ b/bin/variables.ps1
@@ -50,13 +50,6 @@ $smBuildUri = "https://github.com/big-r81/couchdb-sm/releases/download/v${smBuil
 $smBuildFile = "${artifactDir}\$(Split-Path $smBuildUri -Leaf)"
 $smInstallPath = "${toolsDir}\${smBuild}"
 
-# JAVA 8 SETTINGS
-
-# Donwload location of OpenJDK 8 for Windows (x64)
-$java8Build = "zulu8.86.0.25-ca-jdk8.0.452-win_x64"
-$java8BuildUri = "https://cdn.azul.com/zulu/bin/$java8Build.zip"
-$java8BuildFile = "${artifactDir}\$(Split-Path $java8BuildUri -Leaf)"
-
 # JAVA 21 SETTINGS
 
 # Donwload location of OpenJDK 21 for Windows (x64)


### PR DESCRIPTION
The use of Clouseau 2.x is not recommended any longer.  We are in the transition over to Clouseau 3.x instead, which works with Java 21 at the moment.  See https://github.com/apache/couchdb/pull/5761 for further information.